### PR TITLE
Add UsePipeReader and UsePipeWriter extension methods on Stream

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -3,6 +3,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(MSBuildThisFileDirectory)..\bin\$(MSBuildProjectName)\</BaseOutputPath>
+    <LangVersion>7.3</LangVersion>
 
     <!-- VS2017 Test Explorer test navigation and callstack links don't work with portable PDBs yet.
          Also, OpenCover doesn't work with portable PDBs either. -->

--- a/src/Nerdbank.Streams.Tests/StreamExtensionsTests.cs
+++ b/src/Nerdbank.Streams.Tests/StreamExtensionsTests.cs
@@ -1,0 +1,187 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+using System;
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio.Threading;
+using Moq;
+using Nerdbank.Streams;
+using Xunit;
+using Xunit.Abstractions;
+
+public class StreamExtensionsTests : TestBase
+{
+    public StreamExtensionsTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    [Fact]
+    public void UsePipeReader_ThrowsOnNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => StreamExtensions.UsePipeReader(null));
+    }
+
+    [Fact]
+    public void UsePipeReader_NonReadableStream()
+    {
+        var unreadableStream = new Mock<Stream>(MockBehavior.Strict);
+        unreadableStream.SetupGet(s => s.CanRead).Returns(false);
+        Assert.Throws<ArgumentException>(() => unreadableStream.Object.UsePipeReader());
+        unreadableStream.VerifyAll();
+    }
+
+    [Fact]
+    public async Task UsePipeReader()
+    {
+        byte[] expectedBuffer = GetRandomBuffer(2048);
+        var stream = new MemoryStream(expectedBuffer);
+        var reader = stream.UsePipeReader(readBufferSize: 50, this.TimeoutToken);
+        byte[] actualBuffer = new byte[expectedBuffer.Length];
+        int bytesRead = 0;
+        while (bytesRead < expectedBuffer.Length)
+        {
+            var result = await reader.ReadAsync(this.TimeoutToken);
+            foreach (ReadOnlyMemory<byte> segment in result.Buffer)
+            {
+                segment.CopyTo(new Memory<byte>(actualBuffer, bytesRead, actualBuffer.Length - bytesRead));
+                bytesRead += segment.Length;
+            }
+
+            reader.AdvanceTo(result.Buffer.End);
+        }
+
+        // Verify that the end of the stream caused the reader to complete.
+        var lastResult = await reader.ReadAsync(this.TimeoutToken);
+        Assert.Equal(0, lastResult.Buffer.Length);
+        Assert.True(lastResult.IsCompleted);
+
+        // Verify we got the right content.
+        Assert.Equal(expectedBuffer, actualBuffer);
+    }
+
+    [Fact]
+    public async Task UsePipeReader_StreamFails()
+    {
+        var expectedException = new InvalidOperationException();
+        var unreadableStream = new Mock<Stream>(MockBehavior.Strict);
+        unreadableStream.SetupGet(s => s.CanRead).Returns(true);
+
+        // Set up for either ReadAsync method to be called. We expect it will be Memory<T> on .NET Core 2.1 and byte[] on all the others.
+#if NETCOREAPP2_1
+        unreadableStream.Setup(s => s.ReadAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>())).ThrowsAsync(expectedException);
+#else
+        unreadableStream.Setup(s => s.ReadAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ThrowsAsync(expectedException);
+#endif
+
+        var reader = unreadableStream.Object.UsePipeReader();
+        var actualException = await Assert.ThrowsAsync<InvalidOperationException>(() => this.WaitForWriterCompletion(reader));
+        Assert.Same(expectedException, actualException);
+    }
+
+    [Fact]
+    public void UsePipeWriter_ThrowsOnNull()
+    {
+        Assert.Throws<ArgumentNullException>(() => StreamExtensions.UsePipeWriter(null));
+    }
+
+    [Fact]
+    public void UsePipeWriter_NonReadableStream()
+    {
+        var unreadableStream = new Mock<Stream>(MockBehavior.Strict);
+        unreadableStream.SetupGet(s => s.CanWrite).Returns(false);
+        Assert.Throws<ArgumentException>(() => unreadableStream.Object.UsePipeWriter());
+        unreadableStream.VerifyAll();
+    }
+
+    [Fact]
+    public async Task UsePipeWriter()
+    {
+        byte[] expectedBuffer = GetRandomBuffer(2048);
+        var stream = new MemoryStream(expectedBuffer.Length);
+        var writer = stream.UsePipeWriter(this.TimeoutToken);
+        await writer.WriteAsync(expectedBuffer.AsMemory(0, 1024), this.TimeoutToken);
+        await writer.WriteAsync(expectedBuffer.AsMemory(1024, 1024), this.TimeoutToken);
+
+        // As a means of waiting for the async process that copies what we write onto the stream,
+        // complete our writer and wait for the reader to complete also.
+        writer.Complete();
+        await this.WaitForReaderCompletion(writer);
+
+        Assert.Equal(expectedBuffer, stream.ToArray());
+    }
+
+    [Fact]
+    public async Task UsePipeWriter_StreamFails()
+    {
+        var expectedException = new InvalidOperationException();
+        var unreadableStream = new Mock<Stream>(MockBehavior.Strict);
+        unreadableStream.SetupGet(s => s.CanWrite).Returns(true);
+
+        // Set up for either ReadAsync method to be called. We expect it will be Memory<T> on .NET Core 2.1 and byte[] on all the others.
+#if NETCOREAPP2_1
+        unreadableStream.Setup(s => s.WriteAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>())).Throws(expectedException);
+#else
+        unreadableStream.Setup(s => s.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ThrowsAsync(expectedException);
+#endif
+
+        var writer = unreadableStream.Object.UsePipeWriter();
+        await writer.WriteAsync(new byte[1], this.TimeoutToken);
+        var actualException = await Assert.ThrowsAsync<InvalidOperationException>(() => this.WaitForReaderCompletion(writer));
+        Assert.Same(expectedException, actualException);
+    }
+
+    private static byte[] GetRandomBuffer(int length)
+    {
+        var buffer = new byte[length];
+        var random = new Random();
+        random.NextBytes(buffer);
+        return buffer;
+    }
+
+    private Task WaitForReaderCompletion(PipeWriter writer)
+    {
+        Requires.NotNull(writer, nameof(writer));
+
+        var readerDone = new TaskCompletionSource<object>();
+        writer.OnReaderCompleted(
+            (ex, tcs) =>
+            {
+                if (ex != null)
+                {
+                    readerDone.SetException(ex);
+                }
+                else
+                {
+                    readerDone.SetResult(null);
+                }
+            },
+            null);
+        return readerDone.Task.WithCancellation(this.TimeoutToken);
+    }
+
+    private Task WaitForWriterCompletion(PipeReader reader)
+    {
+        Requires.NotNull(reader, nameof(reader));
+
+        var writerDone = new TaskCompletionSource<object>();
+        reader.OnWriterCompleted(
+            (ex, tcs) =>
+            {
+                if (ex != null)
+                {
+                    writerDone.SetException(ex);
+                }
+                else
+                {
+                    writerDone.SetResult(null);
+                }
+            },
+            null);
+        return writerDone.Task.WithCancellation(this.TimeoutToken);
+    }
+}

--- a/src/Nerdbank.Streams/Nerdbank.Streams.csproj
+++ b/src/Nerdbank.Streams/Nerdbank.Streams.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;netstandard1.6;net46</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard1.6;net46;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Release.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <CodeAnalysisRuleSet>..\Nerdbank.Streams.Tests\Nerdbank.Streams.Tests.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <LangVersion>7.3</LangVersion>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard1.6' ">$(DefineConstants);WEBSOCKET;TRACESOURCE</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard1.6' or '$(TargetFramework)' == 'netcoreapp2.1' ">$(DefineConstants);WEBSOCKET;TRACESOURCE</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(DefineConstants);SPAN_BUILTIN</DefineConstants>
 
     <Summary>Streams for full duplex in-proc communication, wrap a WebSocket, split a stream into multiple channels, etc.</Summary>
     <Description>$(Summary)</Description>
@@ -21,9 +21,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.122" PrivateAssets="build;analyzers;compile" />
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.0" />
     <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />

--- a/src/Nerdbank.Streams/StreamExtensions.cs
+++ b/src/Nerdbank.Streams/StreamExtensions.cs
@@ -3,7 +3,15 @@
 
 namespace Nerdbank.Streams
 {
+    using System;
+    using System.Buffers;
     using System.IO;
+    using System.IO.Pipelines;
+    using System.Runtime.InteropServices;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft;
+    using Microsoft.VisualStudio.Threading;
 
     /// <summary>
     /// Stream extension methods.
@@ -17,5 +25,183 @@ namespace Nerdbank.Streams
         /// <param name="length">The number of bytes to read from the parent stream.</param>
         /// <returns>A stream that ends after <paramref name="length"/> bytes are read.</returns>
         public static Stream ReadSlice(this Stream stream, long length) => new NestedStream(stream, length);
+
+        /// <summary>
+        /// Enables efficiently reading a stream using <see cref="PipeReader"/>.
+        /// </summary>
+        /// <param name="stream">The stream to read from using a pipe.</param>
+        /// <param name="readBufferSize">The size of the buffer to ask the stream to fill.</param>
+        /// <param name="cancellationToken">A cancellation token that will cancel task that reads from the stream to fill the pipe.</param>
+        /// <returns>A <see cref="PipeReader"/>.</returns>
+        public static PipeReader UsePipeReader(this Stream stream, int readBufferSize = 2048, CancellationToken cancellationToken = default)
+        {
+            Requires.NotNull(stream, nameof(stream));
+            Requires.Argument(stream.CanRead, nameof(stream), "Stream must be readable.");
+
+            var pipe = new Pipe();
+            Task.Run(async delegate
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    Memory<byte> memory = pipe.Writer.GetMemory(readBufferSize);
+                    try
+                    {
+                        int bytesRead = await stream.ReadAsync(memory, cancellationToken);
+                        if (bytesRead == 0)
+                        {
+                            break;
+                        }
+
+                        pipe.Writer.Advance(bytesRead);
+                    }
+                    catch (Exception ex)
+                    {
+                        pipe.Writer.Complete(ex);
+                        throw;
+                    }
+
+                    FlushResult result = await pipe.Writer.FlushAsync();
+                    if (result.IsCompleted)
+                    {
+                        break;
+                    }
+                }
+
+                // Tell the PipeReader that there's no more data coming
+                pipe.Writer.Complete();
+            }).Forget();
+            return pipe.Reader;
+        }
+
+        /// <summary>
+        /// Enables writing to a stream using <see cref="PipeWriter"/>.
+        /// </summary>
+        /// <param name="stream">The stream to write to using a pipe.</param>
+        /// <param name="cancellationToken">A cancellation token that aborts writing.</param>
+        /// <returns>A <see cref="PipeWriter"/>.</returns>
+        public static PipeWriter UsePipeWriter(this Stream stream, CancellationToken cancellationToken = default)
+        {
+            Requires.NotNull(stream, nameof(stream));
+            Requires.Argument(stream.CanWrite, nameof(stream), "Stream must be writable.");
+
+            var pipe = new Pipe();
+            Task.Run(async delegate
+            {
+                try
+                {
+                    while (true)
+                    {
+                        ReadResult readResult = await pipe.Reader.ReadAsync(cancellationToken);
+                        if (readResult.Buffer.Length > 0)
+                        {
+                            foreach (ReadOnlyMemory<byte> segment in readResult.Buffer)
+                            {
+                                await stream.WriteAsync(segment, cancellationToken);
+                            }
+
+                            await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+                        }
+
+                        pipe.Reader.AdvanceTo(readResult.Buffer.End);
+
+                        if (readResult.IsCompleted)
+                        {
+                            break;
+                        }
+                    }
+
+                    pipe.Reader.Complete();
+                }
+                catch (Exception ex)
+                {
+                    pipe.Reader.Complete(ex);
+                    throw;
+                }
+            }).Forget();
+            return pipe.Writer;
+        }
+
+#if !SPAN_BUILTIN
+#pragma warning disable AvoidAsyncSuffix // Avoid Async suffix
+
+        /// <summary>
+        /// Reads from the stream into a memory buffer.
+        /// </summary>
+        /// <param name="stream">The stream to read from.</param>
+        /// <param name="buffer">The buffer to read directly into.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>The number of bytes actually read.</returns>
+        /// <devremarks>
+        /// This method shamelessly copied from the .NET Core 2.1 Stream class: https://github.com/dotnet/coreclr/blob/a113b1c803783c9d64f1f0e946ff9a853e3bc140/src/System.Private.CoreLib/shared/System/IO/Stream.cs#L366-L391.
+        /// </devremarks>
+        internal static ValueTask<int> ReadAsync(this Stream stream, Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Requires.NotNull(stream, nameof(stream));
+
+            if (MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> array))
+            {
+                return new ValueTask<int>(stream.ReadAsync(array.Array, array.Offset, array.Count, cancellationToken));
+            }
+            else
+            {
+                byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+                return FinishReadAsync(stream.ReadAsync(sharedBuffer, 0, buffer.Length, cancellationToken), sharedBuffer, buffer);
+
+                async ValueTask<int> FinishReadAsync(Task<int> readTask, byte[] localBuffer, Memory<byte> localDestination)
+                {
+                    try
+                    {
+                        int result = await readTask.ConfigureAwait(false);
+                        new Span<byte>(localBuffer, 0, result).CopyTo(localDestination.Span);
+                        return result;
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(localBuffer);
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Writes to a stream from a memory buffer.
+        /// </summary>
+        /// <param name="stream">The stream to write to.</param>
+        /// <param name="buffer">The buffer to read from.</param>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A task that indicates when the write operation is complete.</returns>
+        /// <devremarks>
+        /// This method shamelessly copied from the .NET Core 2.1 Stream class: https://github.com/dotnet/coreclr/blob/a113b1c803783c9d64f1f0e946ff9a853e3bc140/src/System.Private.CoreLib/shared/System/IO/Stream.cs#L672-L696.
+        /// </devremarks>
+        internal static ValueTask WriteAsync(this Stream stream, ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            Requires.NotNull(stream, nameof(stream));
+
+            if (MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> array))
+            {
+                return new ValueTask(stream.WriteAsync(array.Array, array.Offset, array.Count, cancellationToken));
+            }
+            else
+            {
+                byte[] sharedBuffer = ArrayPool<byte>.Shared.Rent(buffer.Length);
+                buffer.Span.CopyTo(sharedBuffer);
+                return new ValueTask(FinishWriteAsync(stream.WriteAsync(sharedBuffer, 0, buffer.Length, cancellationToken), sharedBuffer));
+            }
+
+            async Task FinishWriteAsync(Task writeTask, byte[] localBuffer)
+            {
+                try
+                {
+                    await writeTask.ConfigureAwait(false);
+                }
+                finally
+                {
+                    ArrayPool<byte>.Shared.Return(localBuffer);
+                }
+            }
+        }
+
+#pragma warning restore AvoidAsyncSuffix // Avoid Async suffix
+#endif
     }
 }


### PR DESCRIPTION
This allows accessing a stream using the pipe API.

These extension methods perform the opposite function to the `PipeStream` class, which converts pipe reader/writer into a Stream.