### PR TITLE
Return a custom PipeReader from Stream.UsePipeReader

### DIFF
--- a/src/Nerdbank.Streams/Utilities.cs
+++ b/src/Nerdbank.Streams/Utilities.cs
@@ -84,18 +84,19 @@ namespace Nerdbank.Streams
 
             var writerDone = new TaskCompletionSource<object>();
             reader.OnWriterCompleted(
-                (ex, tcs) =>
+                (ex, wdObject) =>
                 {
+                    var wd = (TaskCompletionSource<object>)wdObject;
                     if (ex != null)
                     {
-                        writerDone.SetException(ex);
+                        wd.SetException(ex);
                     }
                     else
                     {
-                        writerDone.SetResult(null);
+                        wd.SetResult(null);
                     }
                 },
-                null);
+                writerDone);
             return writerDone.Task;
         }
 


### PR DESCRIPTION
This means we read the stream only when asked instead of constantly with an async method.