### PR TITLE
Replace FullDuplexStream+PairedStream with reuse of other streams

### DIFF
--- a/src/Nerdbank.Streams.Tests/MultiplexingStreamTests.cs
+++ b/src/Nerdbank.Streams.Tests/MultiplexingStreamTests.cs
@@ -32,10 +32,10 @@ public class MultiplexingStreamTests : TestBase, IAsyncLifetime
         var mx1TraceSource = new TraceSource(nameof(this.mx1), SourceLevels.All);
         var mx2TraceSource = new TraceSource(nameof(this.mx2), SourceLevels.All);
 
-        mx1TraceSource.Listeners.Add(new XunitTraceListener(this.Logger, nameof(this.mx1)));
-        mx2TraceSource.Listeners.Add(new XunitTraceListener(this.Logger, nameof(this.mx2)));
+        mx1TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+        mx2TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
 
-        (this.transport1, this.transport2) = FullDuplexStream.CreatePair();
+        (this.transport1, this.transport2) = FullDuplexStream.CreatePair(new System.IO.Pipelines.PipeOptions(pauseWriterThreshold: 2 * 1024 * 1024));
         var mx1 = MultiplexingStream.CreateAsync(this.transport1, new MultiplexingStream.Options { TraceSource = mx1TraceSource }, this.TimeoutToken);
         var mx2 = MultiplexingStream.CreateAsync(this.transport2, new MultiplexingStream.Options { TraceSource = mx2TraceSource }, this.TimeoutToken);
         this.mx1 = await mx1;

--- a/src/Nerdbank.Streams.Tests/XunitTraceListener.cs
+++ b/src/Nerdbank.Streams.Tests/XunitTraceListener.cs
@@ -10,14 +10,12 @@ using Xunit.Abstractions;
 internal class XunitTraceListener : TraceListener
 {
     private readonly ITestOutputHelper logger;
-    private readonly string name;
     private readonly StringBuilder lineInProgress = new StringBuilder();
     private bool disposed;
 
-    internal XunitTraceListener(ITestOutputHelper logger, string name)
+    internal XunitTraceListener(ITestOutputHelper logger)
     {
         this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-        this.name = name;
     }
 
     public override bool IsThreadSafe => false;

--- a/src/Nerdbank.Streams/FullDuplexStream.cs
+++ b/src/Nerdbank.Streams/FullDuplexStream.cs
@@ -1,11 +1,13 @@
 ﻿// Copyright (c) Andrew Arnott. All rights reserved.
 // Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
 
+#pragma warning disable AvoidAsyncSuffix // Avoid Async suffix (malfunctions on ValueTask)
+
 namespace Nerdbank.Streams
 {
     using System;
-    using System.Collections.Generic;
     using System.IO;
+    using System.IO.Pipelines;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft;
@@ -20,14 +22,17 @@ namespace Nerdbank.Streams
         /// Creates a pair of streams that can be passed to two parties
         /// to allow for interaction with each other.
         /// </summary>
+        /// <param name="pipeOptions">Pipe options to initialize the internal pipes with.</param>
         /// <returns>A pair of streams.</returns>
-        public static Tuple<Stream, Stream> CreatePair()
+        public static (Stream, Stream) CreatePair(PipeOptions pipeOptions = null)
         {
-            var stream1 = new PairedStream();
-            var stream2 = new PairedStream();
-            stream1.SetOtherStream(stream2);
-            stream2.SetOtherStream(stream1);
-            return Tuple.Create<Stream, Stream>(stream1, stream2);
+            var pipe1 = new Pipe(pipeOptions ?? PipeOptions.Default);
+            var pipe2 = new Pipe(pipeOptions ?? PipeOptions.Default);
+
+            var party1 = new PipeExtensions.DuplexPipe(pipe1.Reader, pipe2.Writer);
+            var party2 = new PipeExtensions.DuplexPipe(pipe2.Reader, pipe1.Writer);
+
+            return (party1.AsStream(), party2.AsStream());
         }
 
         /// <summary>
@@ -112,11 +117,9 @@ namespace Nerdbank.Streams
 
             public override void Write(ReadOnlySpan<byte> buffer) => this.writableStream.Write(buffer);
 
-#pragma warning disable AvoidAsyncSuffix // Avoid Async suffix
             public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default) => this.writableStream.WriteAsync(buffer, cancellationToken);
 
             public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => this.readableStream.ReadAsync(buffer, cancellationToken);
-#pragma warning restore AvoidAsyncSuffix // Avoid Async suffix
 
             public override int Read(Span<byte> buffer) => this.readableStream.Read(buffer);
 
@@ -138,291 +141,6 @@ namespace Nerdbank.Streams
             {
                 Verify.NotDisposed(this);
                 throw ex;
-            }
-        }
-
-        /// <summary>
-        /// The full duplex stream.
-        /// </summary>
-        private class PairedStream : Stream, IDisposableObservable
-        {
-            /// <summary>
-            /// The options to use when creating the value for <see cref="enqueuedSource"/>.
-            /// </summary>
-            private const TaskCreationOptions EnqueuedSourceOptions = TaskCreationOptions.None;
-            private static readonly byte[] EmptyByteArray = new byte[0];
-            private static readonly Task CompletedTask = Task.FromResult<object>(null);
-
-            /// <summary>
-            /// The messages posted by the <see cref="other"/> party,
-            /// for this stream to read.
-            /// </summary>
-            private readonly List<Message> readQueue = new List<Message>();
-
-            /// <summary>
-            /// The completion source for a Task that completes whenever a message
-            /// is enqueued to <see cref="readQueue"/>.
-            /// </summary>
-            private TaskCompletionSource<object> enqueuedSource = new TaskCompletionSource<object>(EnqueuedSourceOptions);
-
-            /// <summary>
-            /// The stream to write to.
-            /// </summary>
-            private PairedStream other;
-
-            /// <inheritdoc />
-            public bool IsDisposed { get; private set; }
-
-            /// <inheritdoc />
-            public override bool CanRead => !this.IsDisposed;
-
-            /// <inheritdoc />
-            public override bool CanSeek => false;
-
-            /// <inheritdoc />
-            public override bool CanWrite => !this.IsDisposed;
-
-            /// <inheritdoc />
-            public override long Length
-            {
-                get => throw this.ThrowDisposedOr(new NotSupportedException());
-            }
-
-            /// <inheritdoc />
-            public override long Position
-            {
-                get => throw this.ThrowDisposedOr(new NotSupportedException());
-                set => throw this.ThrowDisposedOr(new NotSupportedException());
-            }
-
-            /// <inheritdoc />
-            public override void Flush()
-            {
-            }
-
-            /// <inheritdoc />
-            public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            {
-                Requires.NotNull(buffer, nameof(buffer));
-                Requires.Range(offset >= 0, nameof(offset));
-                Requires.Range(count >= 0, nameof(count));
-                Requires.Range(offset + count <= buffer.Length, nameof(count));
-                Verify.NotDisposed(this);
-
-                cancellationToken.ThrowIfCancellationRequested();
-                Message message = null;
-                while (message == null)
-                {
-                    Task waitTask = null;
-                    lock (this.readQueue)
-                    {
-                        if (this.readQueue.Count > 0)
-                        {
-                            message = this.readQueue[0];
-                        }
-                        else
-                        {
-                            waitTask = this.enqueuedSource.Task;
-                        }
-                    }
-
-                    if (waitTask != null)
-                    {
-                        if (cancellationToken.CanBeCanceled)
-                        {
-                            // Arrange to wake up when a new message is posted, or when the caller's CancellationToken is canceled.
-                            var wakeUpEarly = new TaskCompletionSource<object>();
-                            using (cancellationToken.Register(state => ((TaskCompletionSource<object>)state).SetResult(null), wakeUpEarly, false))
-                            {
-                                await Task.WhenAny(waitTask, wakeUpEarly.Task).ConfigureAwait(false);
-                            }
-
-                            cancellationToken.ThrowIfCancellationRequested();
-                        }
-                        else
-                        {
-                            // The caller didn't pass in a CancellationToken. So just do the cheapest thing.
-                            await waitTask.ConfigureAwait(false);
-                        }
-                    }
-                }
-
-                int copiedBytes = message.Consume(buffer, offset, count);
-                if (message.IsConsumed)
-                {
-                    lock (this.readQueue)
-                    {
-                        Assumes.True(this.readQueue[0] == message); // if this fails, the caller is calling Read[Async] in a non-sequential way.
-                        this.readQueue.RemoveAt(0);
-                    }
-                }
-
-                return copiedBytes;
-            }
-
-            /// <inheritdoc />
-            public override int Read(byte[] buffer, int offset, int count)
-            {
-                Requires.NotNull(buffer, nameof(buffer));
-                Requires.Range(offset >= 0, nameof(offset));
-                Requires.Range(count >= 0, nameof(count));
-                Requires.Range(offset + count <= buffer.Length, nameof(count));
-                Verify.NotDisposed(this);
-
-                lock (this.readQueue)
-                {
-                    while (this.readQueue.Count == 0)
-                    {
-                        Monitor.Wait(this.readQueue);
-                    }
-
-                    var message = this.readQueue[0];
-                    int copiedBytes = message.Consume(buffer, offset, count);
-                    if (message.IsConsumed)
-                    {
-                        this.readQueue.RemoveAt(0);
-                    }
-
-                    // Note that the message we just read may not have fully filled
-                    // our caller's available space in the buffer. But that's OK.
-                    // MSDN Stream documentation allows us to return less.
-                    // But we should not return 0 bytes back unless the sender has
-                    // closed their stream.
-                    return copiedBytes;
-                }
-            }
-
-            /// <inheritdoc />
-            public override void Write(byte[] buffer, int offset, int count)
-            {
-                Requires.NotNull(buffer, nameof(buffer));
-                Requires.Range(offset >= 0, nameof(offset));
-                Requires.Range(count >= 0, nameof(count));
-                Requires.Range(offset + count <= buffer.Length, nameof(count));
-                Verify.NotDisposed(this);
-
-                // Avoid sending an empty buffer because that is the signal of a closed stream.
-                if (count > 0)
-                {
-                    byte[] queuedBuffer = new byte[count];
-                    Array.Copy(buffer, offset, queuedBuffer, 0, count);
-                    this.other.PostMessage(new Message(queuedBuffer));
-                }
-            }
-
-            /// <inheritdoc />
-            public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
-            {
-                Verify.NotDisposed(this);
-                cancellationToken.ThrowIfCancellationRequested();
-                this.Write(buffer, offset, count);
-                return CompletedTask;
-            }
-
-            /// <inheritdoc />
-            public override long Seek(long offset, SeekOrigin origin)
-            {
-                Verify.NotDisposed(this);
-                throw new NotSupportedException();
-            }
-
-            /// <inheritdoc />
-            public override void SetLength(long value)
-            {
-                Verify.NotDisposed(this);
-                throw new NotSupportedException();
-            }
-
-            /// <summary>
-            /// Sets the stream to copy written data to.
-            /// </summary>
-            /// <param name="other">The other stream.</param>
-            internal void SetOtherStream(PairedStream other)
-            {
-                Requires.NotNull(other, nameof(other));
-                Assumes.Null(this.other);
-                this.other = other;
-            }
-
-            /// <inheritdoc />
-            protected override void Dispose(bool disposing)
-            {
-                // Sending an empty buffer is the traditional way to signal
-                // that the transmitting stream has closed.
-                this.other.PostMessage(new Message(EmptyByteArray));
-                this.IsDisposed = true;
-                base.Dispose(disposing);
-            }
-
-            /// <summary>
-            /// Posts a message to this stream's read queue.
-            /// </summary>
-            /// <param name="message">The message to transmit.</param>
-            private void PostMessage(Message message)
-            {
-                Requires.NotNull(message, nameof(message));
-
-                TaskCompletionSource<object> enqueuedSource;
-                lock (this.readQueue)
-                {
-                    this.readQueue.Add(message);
-                    Monitor.PulseAll(this.readQueue);
-                    enqueuedSource = Interlocked.Exchange(ref this.enqueuedSource, new TaskCompletionSource<object>(EnqueuedSourceOptions));
-                }
-
-                enqueuedSource.TrySetResult(null);
-            }
-
-            /// <summary>
-            /// Throws <see cref="ObjectDisposedException"/> if the object is disposed,
-            /// otherwise throws the given exception.
-            /// </summary>
-            /// <param name="ex">The new exception to throw.</param>
-            /// <returns>No value is ever returned. This method always throws.</returns>
-            private Exception ThrowDisposedOr(Exception ex)
-            {
-                Verify.NotDisposed(this);
-                throw ex;
-            }
-        }
-
-        private class Message
-        {
-            internal Message(byte[] buffer)
-            {
-                Requires.NotNull(buffer, nameof(buffer));
-
-                this.Buffer = buffer;
-            }
-
-            /// <summary>
-            /// Gets a value indicating whether this message has been read completely
-            /// and should be removed from the queue.
-            /// </summary>
-            /// <remarks>
-            /// This returns <c>false</c> if the buffer was originally empty,
-            /// since that signifies that the other party closed their sending stream.
-            /// </remarks>
-            public bool IsConsumed => this.Position == this.Buffer.Length && this.Buffer.Length > 0;
-
-            /// <summary>
-            /// Gets the buffer to read from.
-            /// </summary>
-            private byte[] Buffer { get; }
-
-            /// <summary>
-            /// Gets or sets the position within the buffer that indicates the first
-            /// character that has not yet been read.
-            /// </summary>
-            private int Position { get; set; }
-
-            public int Consume(byte[] buffer, int offset, int count)
-            {
-                int copiedBytes = Math.Min(count, this.Buffer.Length - this.Position);
-                Array.Copy(this.Buffer, this.Position, buffer, offset, copiedBytes);
-                this.Position += copiedBytes;
-                Assumes.False(this.Position > this.Buffer.Length);
-                return copiedBytes;
             }
         }
     }

--- a/src/Nerdbank.Streams/PipeExtensions.cs
+++ b/src/Nerdbank.Streams/PipeExtensions.cs
@@ -296,7 +296,7 @@ namespace Nerdbank.Streams
             return new DuplexPipe(webSocket.UsePipeReader(sizeHint, pipeOptions, cancellationToken), webSocket.UsePipeWriter(pipeOptions, cancellationToken));
         }
 
-        private class DuplexPipe : IDuplexPipe
+        internal class DuplexPipe : IDuplexPipe
         {
             internal DuplexPipe(PipeReader input, PipeWriter output)
             {

--- a/src/Nerdbank.Streams/PipeStream.cs
+++ b/src/Nerdbank.Streams/PipeStream.cs
@@ -156,6 +156,19 @@ namespace Nerdbank.Streams
         }
 
         /// <inheritdoc />
+        public override int Read(Span<byte> buffer)
+        {
+            Verify.NotDisposed(this);
+            if (this.reader == null)
+            {
+                throw new NotSupportedException();
+            }
+
+            ReadResult readResult = this.reader.ReadAsync().GetAwaiter().GetResult();
+            return this.ReadHelper(buffer, readResult);
+        }
+
+        /// <inheritdoc />
         public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -168,6 +181,19 @@ namespace Nerdbank.Streams
             this.writer.Write(buffer.Span);
             return default;
         }
+
+        /// <inheritdoc />
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            Verify.NotDisposed(this);
+            if (this.writer == null)
+            {
+                throw new NotSupportedException();
+            }
+
+            this.writer.Write(buffer);
+        }
+
 #endif
 
 #pragma warning disable VSTHRD002 // Avoid problematic synchronous waits


### PR DESCRIPTION
The PairedStream wasn't particularly optimized for netcoreapp2.1, but other streams we have implemented are. Rather than maintain so many independent streams, this removes the custom PairedStream implementation in favor of reusing our Pipe-as-Stream code, which already had most of the optimizations we need.

This introduces a requirement that FullDuplexStream paired streams must be flushed after writing before the reader can read it. This is a behavioral breaking change, but is consistent with other streams and actually makes this stream more useful in testing environments since it better emulates most other types of streams (e.g. if product code is failing to flush, that bug will now show up with the new FullDuplexStream behavior).