### PR TITLE
Override more Stream methods on .NET Core 2.1 

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.13" PrivateAssets="all" />
+    <PackageReference Include="Nerdbank.GitVersioning" Version="2.2.33" PrivateAssets="all" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta008" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/IsolatedTestHost/IsolatedTestHost.csproj
+++ b/src/IsolatedTestHost/IsolatedTestHost.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.abstractions" Version="2.0.1" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.3.1" />
+    <PackageReference Include="xunit.abstractions" Version="2.0.3" />
+    <PackageReference Include="xunit.extensibility.core" Version="2.4.1" />
   </ItemGroup>
 
 </Project>

--- a/src/Nerdbank.Streams.Interop.Tests/Nerdbank.Streams.Interop.Tests.csproj
+++ b/src/Nerdbank.Streams.Interop.Tests/Nerdbank.Streams.Interop.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.145" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.192" />
   </ItemGroup>
 
 </Project>

--- a/src/Nerdbank.Streams.Tests/BufferWriterStreamTests.cs
+++ b/src/Nerdbank.Streams.Tests/BufferWriterStreamTests.cs
@@ -148,6 +148,22 @@ public class BufferWriterStreamTests : TestBase
         Assert.Equal(5, this.sequence.AsReadOnlySequence.Length);
     }
 
+#if NETCOREAPP2_1
+
+    [Fact]
+    public void Write_Span()
+    {
+        this.stream.Write(new byte[] { 1, 2, 3, 4, 5 }.AsSpan(1, 3));
+        Assert.Equal(new byte[] { 2, 3, 4 }, this.sequence.AsReadOnlySequence.ToArray());
+        this.stream.Write(new byte[] { 5, 6 }.AsSpan(0, 2));
+        Assert.Equal(new byte[] { 2, 3, 4, 5, 6 }, this.sequence.AsReadOnlySequence.ToArray());
+
+        this.stream.Write(new byte[0].AsSpan(0, 0));
+        Assert.Equal(5, this.sequence.AsReadOnlySequence.Length);
+    }
+
+#endif
+
     [Fact]
     public void WriteAsync_ReturnsSynchronously()
     {
@@ -165,6 +181,22 @@ public class BufferWriterStreamTests : TestBase
         await this.stream.WriteAsync(new byte[0], 0, 0);
         Assert.Equal(5, this.sequence.AsReadOnlySequence.Length);
     }
+
+#if NETCOREAPP2_1
+
+    [Fact]
+    public async Task WriteAsync_Memory()
+    {
+        await this.stream.WriteAsync(new byte[] { 1, 2, 3, 4, 5 }.AsMemory(1, 3));
+        Assert.Equal(new byte[] { 2, 3, 4 }, this.sequence.AsReadOnlySequence.ToArray());
+        await this.stream.WriteAsync(new byte[] { 5, 6 }.AsMemory(0, 2));
+        Assert.Equal(new byte[] { 2, 3, 4, 5, 6 }, this.sequence.AsReadOnlySequence.ToArray());
+
+        await this.stream.WriteAsync(new byte[0].AsMemory(0, 0));
+        Assert.Equal(5, this.sequence.AsReadOnlySequence.Length);
+    }
+
+#endif
 
     [Fact]
     public void WriteByte()
@@ -195,15 +227,27 @@ public class BufferWriterStreamTests : TestBase
     public void Read_IsNotSupported()
     {
         Assert.Throws<NotSupportedException>(() => this.stream.Read(new byte[1], 0, 1));
+#if NETCOREAPP2_1
+        Assert.Throws<NotSupportedException>(() => this.stream.Read(new byte[1].AsSpan(0, 1)));
+#endif
         this.stream.Dispose();
         Assert.Throws<ObjectDisposedException>(() => this.stream.Read(new byte[1], 0, 1));
+#if NETCOREAPP2_1
+        Assert.Throws<ObjectDisposedException>(() => this.stream.Read(new byte[1].AsSpan(0, 1)));
+#endif
     }
 
     [Fact]
     public async Task ReadAsync_IsNotSupported()
     {
         await Assert.ThrowsAsync<NotSupportedException>(() => this.stream.ReadAsync(new byte[1], 0, 1));
+#if NETCOREAPP2_1
+        await Assert.ThrowsAsync<NotSupportedException>(() => this.stream.ReadAsync(new byte[1].AsMemory(0, 1)).AsTask());
+#endif
         this.stream.Dispose();
         await Assert.ThrowsAsync<ObjectDisposedException>(() => this.stream.ReadAsync(new byte[1], 0, 1));
+#if NETCOREAPP2_1
+        await Assert.ThrowsAsync<ObjectDisposedException>(() => this.stream.ReadAsync(new byte[1].AsMemory(0, 1)).AsTask());
+#endif
     }
 }

--- a/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
+++ b/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
@@ -16,16 +16,22 @@
     <Compile Include="..\Nerdbank.Streams\Utilities.cs" Link="Utilities.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.122" />
-    <PackageReference Include="PInvoke.Kernel32" Version="0.5.152" />
-    <PackageReference Include="StreamJsonRpc" Version="1.4.110-beta" />
-    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.192" />
+    <PackageReference Include="PInvoke.Kernel32" Version="0.5.155" />
+    <PackageReference Include="StreamJsonRpc" Version="1.4.134" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.combinatorial" Version="1.2.7" />
-    <PackageReference Include="xunit.skippablefact" Version="1.3.6" />
-    <PackageReference Include="xunit.runner.console" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
-    <PackageReference Include="Moq" Version="4.8.3" />
+    <PackageReference Include="xunit.skippablefact" Version="1.3.12" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.1" />
     <PackageReference Include="OpenCover" Version="4.6.519" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
   </ItemGroup>

--- a/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.ruleset
+++ b/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.ruleset
@@ -78,7 +78,8 @@
     <Rule Id="UseConfigureAwait" Action="Error" />
   </Rules>
   <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers">
-    <Rule Id="VSTHRD200" Action="Hidden" />
     <Rule Id="VSTHRD103" Action="Hidden" />
+    <Rule Id="VSTHRD111" Action="None" />
+    <Rule Id="VSTHRD200" Action="Hidden" />
   </Rules>
 </RuleSet>

--- a/src/Nerdbank.Streams.Tests/ProcessJobTracker.cs
+++ b/src/Nerdbank.Streams.Tests/ProcessJobTracker.cs
@@ -45,9 +45,9 @@ internal class ProcessJobTracker : IDisposable
         string jobName = nameof(ProcessJobTracker) + Process.GetCurrentProcess().Id;
         this.jobHandle = CreateJobObject(IntPtr.Zero, jobName);
 
-        var extendedInfo = new JOB_OBJECT_EXTENDED_LIMIT_INFORMATION
+        var extendedInfo = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
         {
-            BasicLimitInformation = new JOB_OBJECT_BASIC_LIMIT_INFORMATION
+            BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
             {
                 LimitFlags = JOB_OBJECT_LIMIT_FLAGS.JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
             },
@@ -62,14 +62,14 @@ internal class ProcessJobTracker : IDisposable
             Marshal.StructureToPtr(extendedInfo, pExtendedInfo, fDeleteOld: false);
             try
             {
-                if (!SetInformationJobObject(this.jobHandle, JOBOBJECT_INFO_CLASS.JobObjectExtendedLimitInformation, pExtendedInfo, (uint)length))
+                if (!SetInformationJobObject(this.jobHandle, JOBOBJECTINFOCLASS.JobObjectExtendedLimitInformation, pExtendedInfo, (uint)length))
                 {
                     throw new Win32Exception();
                 }
             }
             finally
             {
-                Marshal.DestroyStructure<JOB_OBJECT_EXTENDED_LIMIT_INFORMATION>(pExtendedInfo);
+                Marshal.DestroyStructure<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>(pExtendedInfo);
             }
         }
         finally

--- a/src/Nerdbank.Streams/BufferWriterStream.cs
+++ b/src/Nerdbank.Streams/BufferWriterStream.cs
@@ -97,6 +97,33 @@ namespace Nerdbank.Streams
             this.writer.Advance(1);
         }
 
+#if NETCOREAPP2_1
+
+        /// <inheritdoc/>
+        public override int Read(Span<byte> buffer) => throw this.ThrowDisposedOr(new NotSupportedException());
+
+        /// <inheritdoc/>
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default) => throw this.ThrowDisposedOr(new NotSupportedException());
+
+        /// <inheritdoc/>
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            Verify.NotDisposed(this);
+            var span = this.writer.GetSpan(buffer.Length);
+            buffer.CopyTo(span);
+            this.writer.Advance(buffer.Length);
+        }
+
+        /// <inheritdoc/>
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            this.Write(buffer.Span);
+            return default;
+        }
+
+#endif
+
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {

--- a/src/Nerdbank.Streams/HalfDuplexStream.cs
+++ b/src/Nerdbank.Streams/HalfDuplexStream.cs
@@ -75,7 +75,7 @@ namespace Nerdbank.Streams
         public void CompleteWriting() => this.pipe.Writer.Complete();
 
         /// <inheritdoc />
-        public override async Task FlushAsync(CancellationToken cancellationToken) => await this.pipe.Writer.FlushAsync(cancellationToken);
+        public override async Task FlushAsync(CancellationToken cancellationToken) => await this.pipe.Writer.FlushAsync(cancellationToken).ConfigureAwait(false);
 
         /// <inheritdoc />
         public override long Seek(long offset, SeekOrigin origin) => throw this.ThrowDisposedOr(new NotSupportedException());
@@ -91,7 +91,7 @@ namespace Nerdbank.Streams
             Requires.Range(offset >= 0, nameof(offset));
             Requires.Range(count > 0, nameof(count));
 
-            ReadResult readResult = await this.pipe.Reader.ReadAsync(cancellationToken);
+            ReadResult readResult = await this.pipe.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
             int bytesRead = 0;
             System.Buffers.ReadOnlySequence<byte> slice = readResult.Buffer.Slice(0, Math.Min(count, readResult.Buffer.Length));
             foreach (ReadOnlyMemory<byte> span in slice)

--- a/src/Nerdbank.Streams/Nerdbank.Streams.csproj
+++ b/src/Nerdbank.Streams/Nerdbank.Streams.csproj
@@ -18,10 +18,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.122" PrivateAssets="build;analyzers;compile" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="15.8.192" PrivateAssets="build;analyzers;compile" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.IO.Pipelines" Version="4.5.1" />
-    <PackageReference Include="AsyncUsageAnalyzers" Version="1.0.0-alpha003" PrivateAssets="all" />
+    <PackageReference Include="System.IO.Pipelines" Version="4.5.2" />
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/src/Nerdbank.Streams/PipeExtensions.cs
+++ b/src/Nerdbank.Streams/PipeExtensions.cs
@@ -64,7 +64,7 @@ namespace Nerdbank.Streams
                     Memory<byte> memory = pipe.Writer.GetMemory(sizeHint);
                     try
                     {
-                        int bytesRead = await stream.ReadAsync(memory, cancellationToken);
+                        int bytesRead = await stream.ReadAsync(memory, cancellationToken).ConfigureAwait(false);
                         if (bytesRead == 0)
                         {
                             break;
@@ -78,7 +78,7 @@ namespace Nerdbank.Streams
                         throw;
                     }
 
-                    FlushResult result = await pipe.Writer.FlushAsync();
+                    FlushResult result = await pipe.Writer.FlushAsync().ConfigureAwait(false);
                     if (result.IsCompleted)
                     {
                         break;
@@ -128,12 +128,12 @@ namespace Nerdbank.Streams
                 {
                     while (!cancellationToken.IsCancellationRequested)
                     {
-                        ReadResult readResult = await pipe.Reader.ReadAsync(cancellationToken);
+                        ReadResult readResult = await pipe.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
                         if (readResult.Buffer.Length > 0)
                         {
                             foreach (ReadOnlyMemory<byte> segment in readResult.Buffer)
                             {
-                                await stream.WriteAsync(segment, cancellationToken);
+                                await stream.WriteAsync(segment, cancellationToken).ConfigureAwait(false);
                             }
 
                             await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
@@ -209,7 +209,7 @@ namespace Nerdbank.Streams
                     Memory<byte> memory = pipe.Writer.GetMemory(sizeHint);
                     try
                     {
-                        var readResult = await webSocket.ReceiveAsync(memory, cancellationToken);
+                        var readResult = await webSocket.ReceiveAsync(memory, cancellationToken).ConfigureAwait(false);
                         if (readResult.Count == 0)
                         {
                             break;
@@ -223,7 +223,7 @@ namespace Nerdbank.Streams
                         throw;
                     }
 
-                    FlushResult result = await pipe.Writer.FlushAsync();
+                    FlushResult result = await pipe.Writer.FlushAsync().ConfigureAwait(false);
                     if (result.IsCompleted)
                     {
                         break;
@@ -255,12 +255,12 @@ namespace Nerdbank.Streams
                 {
                     while (!cancellationToken.IsCancellationRequested)
                     {
-                        ReadResult readResult = await pipe.Reader.ReadAsync(cancellationToken);
+                        ReadResult readResult = await pipe.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
                         if (readResult.Buffer.Length > 0)
                         {
                             foreach (ReadOnlyMemory<byte> segment in readResult.Buffer)
                             {
-                                await webSocket.SendAsync(segment, WebSocketMessageType.Binary, endOfMessage: true, cancellationToken);
+                                await webSocket.SendAsync(segment, WebSocketMessageType.Binary, endOfMessage: true, cancellationToken).ConfigureAwait(false);
                             }
                         }
 

--- a/src/Nerdbank.Streams/PipeStream.cs
+++ b/src/Nerdbank.Streams/PipeStream.cs
@@ -170,7 +170,9 @@ namespace Nerdbank.Streams
                 throw new NotSupportedException();
             }
 
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
             ReadResult readResult = this.reader.ReadAsync().GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
             return this.ReadHelper(buffer, readResult);
         }
 

--- a/src/Nerdbank.Streams/StreamPipeReader.cs
+++ b/src/Nerdbank.Streams/StreamPipeReader.cs
@@ -127,7 +127,7 @@ namespace Nerdbank.Streams
             {
                 try
                 {
-                    int bytesRead = await this.stream.ReadAsync(memory, cts.Token);
+                    int bytesRead = await this.stream.ReadAsync(memory, cts.Token).ConfigureAwait(false);
                     if (bytesRead == 0)
                     {
                         this.CompleteWriting();

--- a/src/Nerdbank.Streams/Substream.cs
+++ b/src/Nerdbank.Streams/Substream.cs
@@ -166,7 +166,7 @@ namespace Nerdbank.Streams
             else
             {
                 int totalCount = this.count + count;
-                await this.WriteLengthHeaderAsync(totalCount, cancellationToken);
+                await this.WriteLengthHeaderAsync(totalCount, cancellationToken).ConfigureAwait(false);
                 await this.underlyingStream.WriteAsync(this.buffer, 0, this.count).ConfigureAwait(false);
                 await this.underlyingStream.WriteAsync(buffer, offset, count).ConfigureAwait(false);
                 this.count = 0;


### PR DESCRIPTION
- Add missing .ConfigureAwait(false) for all awaits
- Override more Stream methods on .NET Core 2.1 

Closes #43