### PR TITLE
Add Sequence<T>.MinimumSpanLength

### DIFF
--- a/src/Nerdbank.Streams.Tests/SequenceTests.cs
+++ b/src/Nerdbank.Streams.Tests/SequenceTests.cs
@@ -30,7 +30,8 @@ public class SequenceTests : TestBase
     [Fact]
     public void GetMemory_Sizes()
     {
-        var seq = new Sequence<char>();
+        var seq = new Sequence<char>(new MockPool<char>());
+        seq.MinimumSpanLength = 1;
 
         var mem1 = seq.GetMemory(16);
         Assert.Equal(16, mem1.Length);
@@ -52,6 +53,7 @@ public class SequenceTests : TestBase
     {
         MockPool<char> mockPool = new MockPool<char>();
         var seq = new Sequence<char>(mockPool);
+        seq.MinimumSpanLength = 1;
 
         for (int i = 0; i < leadingBlocks; i++)
         {
@@ -203,11 +205,11 @@ public class SequenceTests : TestBase
         MockPool<char> mockPool = new MockPool<char>();
         var seq = new Sequence<char>(mockPool);
 
-        var mem1 = seq.GetMemory(3);
+        var mem1 = seq.GetMemory(3).Slice(0, 3);
         mem1.Span.Fill('a');
         seq.Advance(mem1.Length);
 
-        var mem2 = seq.GetMemory(3);
+        var mem2 = seq.GetMemory(3).Slice(0, 3);
         mem2.Span.Fill('b');
         seq.Advance(mem2.Length);
 
@@ -227,11 +229,11 @@ public class SequenceTests : TestBase
         MockPool<char> mockPool = new MockPool<char>();
         var seq = new Sequence<char>(mockPool);
 
-        var mem1 = seq.GetMemory(3);
+        var mem1 = seq.GetMemory(3).Slice(0, 3);
         mem1.Span.Fill('a');
         seq.Advance(mem1.Length);
 
-        var mem2 = seq.GetMemory(3);
+        var mem2 = seq.GetMemory(3).Slice(0, 3);
         mem2.Span.Fill('b');
         seq.Advance(mem2.Length);
 
@@ -253,11 +255,11 @@ public class SequenceTests : TestBase
         var seqA = new Sequence<char>(mockPool);
         var seqB = new Sequence<char>(mockPool);
 
-        var mem1 = seqA.GetMemory(3);
+        var mem1 = seqA.GetMemory(3).Slice(0, 3);
         mem1.Span.Fill('a');
         seqA.Advance(mem1.Length);
 
-        var mem2 = seqB.GetMemory(3);
+        var mem2 = seqB.GetMemory(3).Slice(0, 3);
         mem2.Span.Fill('b');
         seqB.Advance(mem2.Length);
 
@@ -333,6 +335,25 @@ public class SequenceTests : TestBase
         seq.Advance(10);
 
         Assert.Equal(10 - 3 + 10 + 10, seq.AsReadOnlySequence.Length);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(5)]
+    [InlineData(64)]
+    [InlineData(2048)]
+    [InlineData(4096)]
+    public void MinimumSpanLength(int minLength)
+    {
+        var seq = new Sequence<int>();
+        Assert.True(seq.MinimumSpanLength > 0);
+        seq.MinimumSpanLength = minLength;
+        Assert.Equal(minLength, seq.MinimumSpanLength);
+        var span = seq.GetSpan(1);
+        Assert.True(span.Length >= seq.MinimumSpanLength);
+
+        seq.Reset();
+        Assert.Equal(minLength, seq.MinimumSpanLength);
     }
 
     [Fact]

--- a/src/Nerdbank.Streams/Sequence`1.cs
+++ b/src/Nerdbank.Streams/Sequence`1.cs
@@ -51,6 +51,27 @@ namespace Nerdbank.Streams
         }
 
         /// <summary>
+        /// Gets or sets the minimum length for an allocated to store more data.
+        /// </summary>
+        /// <value>The default value is 32, but this may change in future versions to tune for more general applicability.</value>
+        /// <remarks>
+        /// <para>
+        /// Each time <see cref="GetSpan(int)"/> or <see cref="GetMemory(int)"/> is called,
+        /// previously allocated memory is used if it is large enough to satisfy the length demand.
+        /// If new memory must be allocated, the argument to one of these methods typically dictate
+        /// the length of array to allocate. When the caller uses very small values (just enough for its immediate need)
+        /// but the high level scenario can predict that a large amount of memory will be ultimately required,
+        /// it can be advisable to set this property to a value such that just a few larger arrays are allocated
+        /// instead of many small ones.
+        /// </para>
+        /// <para>
+        /// The <see cref="MemoryPool{T}"/> in use may itself have a minimum array length as well,
+        /// in which case the higher of the two minimums dictate the minimum array size that will be allocated.
+        /// </para>
+        /// </remarks>
+        public int MinimumSpanLength { get; set; } = 32;
+
+        /// <summary>
         /// Gets this sequence expressed as a <see cref="ReadOnlySequence{T}"/>.
         /// </summary>
         /// <returns>A read only sequence representing the data in this object.</returns>
@@ -160,7 +181,7 @@ namespace Nerdbank.Streams
 
             if (this.last == null || this.last.WritableBytes < sizeHint)
             {
-                this.Append(this.memoryPool.Rent(sizeHint));
+                this.Append(this.memoryPool.Rent(Math.Max(this.MinimumSpanLength, sizeHint)));
             }
 
             return this.last.TrailingSlack;


### PR DESCRIPTION
This for example allows serializers to set a large value so that the result is a few large arrays instead of many tiny ones.

Closes #52