### PR TITLE
Add net472 target

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,17 +20,18 @@ jobs:
 - job: Windows
   pool: Hosted VS2017
   steps:
-  - script: |
-      dotnet tool install --tool-path . nbgv
-      .\nbgv cloud -p src
-    displayName: Set build number
-    condition: ne(variables['system.pullrequest.isfork'], true)
-
   - task: DotNetCoreInstaller@0
-    displayName: Install .NET Core SDK 2.1.503
+    displayName: Install .NET Core SDK 2.2.104
     inputs:
       packageType: sdk
-      version: 2.1.503
+      version: 2.2.104
+
+  - script: |
+      dotnet tool install --tool-path .. nbgv
+      ..\nbgv cloud
+    workingDirectory: src
+    displayName: Set build number
+    condition: ne(variables['system.pullrequest.isfork'], true)
 
   - script: dotnet --info
     displayName: Show dotnet SDK info

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,7 +31,6 @@ jobs:
       ..\nbgv cloud
     workingDirectory: src
     displayName: Set build number
-    condition: ne(variables['system.pullrequest.isfork'], true)
 
   - script: dotnet --info
     displayName: Show dotnet SDK info
@@ -88,7 +87,7 @@ jobs:
       ArtifactName: projectAssetsJson
       ArtifactType: Container
     displayName: Publish projectAssetsJson artifacts
-    condition: and(succeededOrFailed(), ne(variables['system.pullrequest.isfork'], true))
+    condition: succeededOrFailed()
 
   - task: PublishBuildArtifacts@1
     inputs:
@@ -96,16 +95,7 @@ jobs:
       ArtifactName: build_logs
       ArtifactType: Container
     displayName: Publish build_logs artifacts
-    condition: and(succeededOrFailed(), ne(variables['system.pullrequest.isfork'], true))
-
-  ## The rest of these steps are for deployment and skipped for PR builds
-
-  #- task: PublishBuildArtifacts@1
-  #  inputs:
-  #    PathtoPublish: $(build.sourcesdirectory)/bin
-  #    ArtifactName: bin
-  #    ArtifactType: Container
-  #  condition: and(succeeded(), ne(variables['system.pullrequest.isfork'], true))
+    condition: succeededOrFailed()
 
   - task: DotNetCoreCLI@2
     displayName: Pack
@@ -143,7 +133,6 @@ jobs:
       ArtifactName: deployables
       ArtifactType: Container
     displayName: Publish deployables artifacts
-    condition: and(succeeded(), ne(variables['system.pullrequest.isfork'], true))
 
 - job: Linux
   pool:

--- a/azure-pipelines/testfx.yml
+++ b/azure-pipelines/testfx.yml
@@ -1,4 +1,6 @@
 steps:
+- script: dotnet --info
+  displayName: Show dotnet SDK info
 - script: dotnet restore
   displayName: Restore packages
   workingDirectory: ${{ parameters.projectdirectory }}

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -4,7 +4,7 @@
     <BaseIntermediateOutputPath>$(MSBuildThisFileDirectory)..\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(MSBuildThisFileDirectory)..\bin\$(MSBuildProjectName)\</BaseOutputPath>
     <LangVersion>7.3</LangVersion>
-    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">$(DefineConstants);SPAN_BUILTIN</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFramework)' == 'netcoreapp2.1' or '$(TargetFramework)' == 'netcoreapp2.2' ">$(DefineConstants);SPAN_BUILTIN</DefineConstants>
 
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Nerdbank.Streams.Tests/BufferWriterStreamTests.cs
+++ b/src/Nerdbank.Streams.Tests/BufferWriterStreamTests.cs
@@ -148,7 +148,7 @@ public class BufferWriterStreamTests : TestBase
         Assert.Equal(5, this.sequence.AsReadOnlySequence.Length);
     }
 
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
 
     [Fact]
     public void Write_Span()
@@ -182,7 +182,7 @@ public class BufferWriterStreamTests : TestBase
         Assert.Equal(5, this.sequence.AsReadOnlySequence.Length);
     }
 
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
 
     [Fact]
     public async Task WriteAsync_Memory()
@@ -227,12 +227,12 @@ public class BufferWriterStreamTests : TestBase
     public void Read_IsNotSupported()
     {
         Assert.Throws<NotSupportedException>(() => this.stream.Read(new byte[1], 0, 1));
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         Assert.Throws<NotSupportedException>(() => this.stream.Read(new byte[1].AsSpan(0, 1)));
 #endif
         this.stream.Dispose();
         Assert.Throws<ObjectDisposedException>(() => this.stream.Read(new byte[1], 0, 1));
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         Assert.Throws<ObjectDisposedException>(() => this.stream.Read(new byte[1].AsSpan(0, 1)));
 #endif
     }
@@ -241,12 +241,12 @@ public class BufferWriterStreamTests : TestBase
     public async Task ReadAsync_IsNotSupported()
     {
         await Assert.ThrowsAsync<NotSupportedException>(() => this.stream.ReadAsync(new byte[1], 0, 1));
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         await Assert.ThrowsAsync<NotSupportedException>(() => this.stream.ReadAsync(new byte[1].AsMemory(0, 1)).AsTask());
 #endif
         this.stream.Dispose();
         await Assert.ThrowsAsync<ObjectDisposedException>(() => this.stream.ReadAsync(new byte[1], 0, 1));
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         await Assert.ThrowsAsync<ObjectDisposedException>(() => this.stream.ReadAsync(new byte[1].AsMemory(0, 1)).AsTask());
 #endif
     }

--- a/src/Nerdbank.Streams.Tests/FullDuplexStreamCombineTests.cs
+++ b/src/Nerdbank.Streams.Tests/FullDuplexStreamCombineTests.cs
@@ -219,7 +219,7 @@ public class FullDuplexStreamCombineTests : TestBase
         writableMock.VerifyAll();
     }
 
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
     [Fact]
     public void ReadAsync_Memory()
     {

--- a/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
+++ b/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;net472;netcoreapp1.0;netcoreapp2.0;netcoreapp2.1;netcoreapp2.2</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
+++ b/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net461;net472;netcoreapp1.0;netcoreapp2.0;netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);CS1591</NoWarn>

--- a/src/Nerdbank.Streams.Tests/ReadOnlySequenceStreamTests.cs
+++ b/src/Nerdbank.Streams.Tests/ReadOnlySequenceStreamTests.cs
@@ -150,12 +150,12 @@ public class ReadOnlySequenceStreamTests : TestBase
     public void Write()
     {
         Assert.Throws<NotSupportedException>(() => this.defaultStream.Write(new byte[1], 0, 1));
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         Assert.Throws<NotSupportedException>(() => this.defaultStream.Write(new byte[1].AsSpan(0, 1)));
 #endif
         this.defaultStream.Dispose();
         Assert.Throws<ObjectDisposedException>(() => this.defaultStream.Write(new byte[1], 0, 1));
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         Assert.Throws<ObjectDisposedException>(() => this.defaultStream.Write(new byte[1].AsSpan(0, 1)));
 #endif
     }
@@ -164,12 +164,12 @@ public class ReadOnlySequenceStreamTests : TestBase
     public async Task WriteAsync()
     {
         await Assert.ThrowsAsync<NotSupportedException>(() => this.defaultStream.WriteAsync(new byte[1], 0, 1));
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         await Assert.ThrowsAsync<NotSupportedException>(() => this.defaultStream.WriteAsync(new byte[1].AsMemory(0, 1)).AsTask());
 #endif
         this.defaultStream.Dispose();
         await Assert.ThrowsAsync<ObjectDisposedException>(() => this.defaultStream.WriteAsync(new byte[1], 0, 1));
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         await Assert.ThrowsAsync<ObjectDisposedException>(() => this.defaultStream.WriteAsync(new byte[1].AsMemory(0, 1)).AsTask());
 #endif
     }
@@ -272,7 +272,7 @@ public class ReadOnlySequenceStreamTests : TestBase
         Assert.Equal(9, stream.Position);
     }
 
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
 
     [Fact]
     public void Read_Span()
@@ -340,7 +340,7 @@ public class ReadOnlySequenceStreamTests : TestBase
         Assert.Equal(9, stream.Position);
     }
 
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
 
     [Fact]
     public async Task ReadAsync_Memory_Works()

--- a/src/Nerdbank.Streams.Tests/StreamUsePipeReaderTests.cs
+++ b/src/Nerdbank.Streams.Tests/StreamUsePipeReaderTests.cs
@@ -30,7 +30,7 @@ public class StreamUsePipeReaderTests : StreamPipeReaderTestBase
         unreadableStream.SetupGet(s => s.CanRead).Returns(true);
 
         // Set up for either ReadAsync method to be called. We expect it will be Memory<T> on .NET Core 2.1 and byte[] on all the others.
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         unreadableStream.Setup(s => s.ReadAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>())).ThrowsAsync(expectedException);
 #else
         unreadableStream.Setup(s => s.ReadAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ThrowsAsync(expectedException);

--- a/src/Nerdbank.Streams.Tests/StreamUsePipeWriterTests.cs
+++ b/src/Nerdbank.Streams.Tests/StreamUsePipeWriterTests.cs
@@ -30,7 +30,7 @@ public class StreamUsePipeWriterTests : StreamPipeWriterTestBase
         unreadableStream.SetupGet(s => s.CanWrite).Returns(true);
 
         // Set up for either WriteAsync method to be called. We expect it will be Memory<T> on .NET Core 2.1 and byte[] on all the others.
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         unreadableStream.Setup(s => s.WriteAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>())).Throws(expectedException);
 #else
         unreadableStream.Setup(s => s.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ThrowsAsync(expectedException);

--- a/src/Nerdbank.Streams.Tests/StreamUseStrictPipeReaderTests.cs
+++ b/src/Nerdbank.Streams.Tests/StreamUseStrictPipeReaderTests.cs
@@ -30,7 +30,7 @@ public class StreamUseStrictPipeReaderTests : StreamPipeReaderTestBase
         unreadableStream.SetupGet(s => s.CanRead).Returns(true);
 
         // Set up for either ReadAsync method to be called. We expect it will be Memory<T> on .NET Core 2.1 and byte[] on all the others.
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         unreadableStream.Setup(s => s.ReadAsync(It.IsAny<Memory<byte>>(), It.IsAny<CancellationToken>())).ThrowsAsync(expectedException);
 #else
         unreadableStream.Setup(s => s.ReadAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ThrowsAsync(expectedException);

--- a/src/Nerdbank.Streams.Tests/StreamUseStrictPipeWriterTests.cs
+++ b/src/Nerdbank.Streams.Tests/StreamUseStrictPipeWriterTests.cs
@@ -29,7 +29,7 @@ public class StreamUseStrictPipeWriterTests : StreamPipeWriterTestBase
         unreadableStream.SetupGet(s => s.CanWrite).Returns(true);
 
         // Set up for either WriteAsync method to be called. We expect it will be Memory<T> on .NET Core 2.1 and byte[] on all the others.
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         unreadableStream.Setup(s => s.WriteAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>())).Throws(expectedException);
 #else
         unreadableStream.Setup(s => s.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).ThrowsAsync(expectedException);
@@ -48,7 +48,7 @@ public class StreamUseStrictPipeWriterTests : StreamPipeWriterTestBase
         var writeCompletedSource = new TaskCompletionSource<object>();
 
         // Set up for either WriteAsync method to be called. We expect it will be Memory<T> on .NET Core 2.1 and byte[] on all the others.
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         streamMock.Setup(s => s.WriteAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>())).Returns(new ValueTask(writeCompletedSource.Task));
 #else
         streamMock.Setup(s => s.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(writeCompletedSource.Task);
@@ -73,7 +73,7 @@ public class StreamUseStrictPipeWriterTests : StreamPipeWriterTestBase
         var writeCompletedSource = new TaskCompletionSource<object>();
 
         // Set up for either WriteAsync method to be called. We expect it will be Memory<T> on .NET Core 2.1 and byte[] on all the others.
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
         streamMock.Setup(s => s.WriteAsync(It.IsAny<ReadOnlyMemory<byte>>(), It.IsAny<CancellationToken>())).Returns(new ValueTask(writeCompletedSource.Task));
 #else
         streamMock.Setup(s => s.WriteAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>())).Returns(writeCompletedSource.Task);

--- a/src/Nerdbank.Streams/BufferWriterStream.cs
+++ b/src/Nerdbank.Streams/BufferWriterStream.cs
@@ -97,7 +97,7 @@ namespace Nerdbank.Streams
             this.writer.Advance(1);
         }
 
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
 
         /// <inheritdoc/>
         public override int Read(Span<byte> buffer) => throw this.ThrowDisposedOr(new NotSupportedException());

--- a/src/Nerdbank.Streams/FullDuplexStream.cs
+++ b/src/Nerdbank.Streams/FullDuplexStream.cs
@@ -113,7 +113,7 @@ namespace Nerdbank.Streams
 
             public override void WriteByte(byte value) => this.writableStream.WriteByte(value);
 
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
 
             public override void Write(ReadOnlySpan<byte> buffer) => this.writableStream.Write(buffer);
 

--- a/src/Nerdbank.Streams/MultiplexingProtocolException.cs
+++ b/src/Nerdbank.Streams/MultiplexingProtocolException.cs
@@ -8,7 +8,7 @@ namespace Nerdbank.Streams
     /// <summary>
     /// An exception that is thrown when an error occurs on the remote side of a multiplexed connection.
     /// </summary>
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if !NETSTANDARD1_6
     [System.Serializable]
 #endif
     public class MultiplexingProtocolException : Exception
@@ -39,7 +39,7 @@ namespace Nerdbank.Streams
         {
         }
 
-#if NETFRAMEWORK || NETSTANDARD2_0
+#if !NETSTANDARD1_6
         /// <summary>
         /// Initializes a new instance of the <see cref="MultiplexingProtocolException"/> class
         /// for use in deserialization.

--- a/src/Nerdbank.Streams/Nerdbank.Streams.csproj
+++ b/src/Nerdbank.Streams/Nerdbank.Streams.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net46;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net46;net472;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\release.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/src/Nerdbank.Streams/ReadOnlySequenceStream.cs
+++ b/src/Nerdbank.Streams/ReadOnlySequenceStream.cs
@@ -171,7 +171,7 @@ namespace Nerdbank.Streams
             }
         }
 
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
 
         /// <inheritdoc/>
         public override int Read(Span<byte> buffer)

--- a/src/Nerdbank.Streams/Substream.cs
+++ b/src/Nerdbank.Streams/Substream.cs
@@ -198,7 +198,7 @@ namespace Nerdbank.Streams
         {
             Span<byte> intBytes = stackalloc byte[4];
             Utilities.Write(intBytes, length);
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
             this.underlyingStream.Write(intBytes);
 #else
             this.underlyingStream.Write(intBytes.ToArray(), 0, intBytes.Length);
@@ -213,7 +213,7 @@ namespace Nerdbank.Streams
             Utilities.Write(intBytes, length);
             try
             {
-#if NETCOREAPP2_1
+#if SPAN_BUILTIN
                 await this.underlyingStream.WriteAsync(intBytes.AsMemory(0, 4), cancellationToken).ConfigureAwait(false);
 #else
                 await this.underlyingStream.WriteAsync(intBytes, 0, sizeof(int), cancellationToken).ConfigureAwait(false);

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "2.1.503"
+    "version": "2.2.104"
   },
   "msbuild-sdks": {
     "MSBuild.Sdk.Extras": "1.6.61"


### PR DESCRIPTION
Also revise our #if directives to make it clearer that they'll behave when adding more targets in the future.
Also test on netcoreapp2.2

The net472 target is equivalent to the net46 one, except it compiles against newer reference assemblies and thus a few dependencies are dropped, allowing for higher performance since facade assemblies don't have to load at runtime.