### PR TITLE
Sequence<T> perf enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@ bld/
 [Bb]in/
 [Oo]bj/
 
+# BenchmarkDotNet reports
+BenchmarkDotNet.Artifacts/
+
 # Visual Studio 2015 cache/options directory
 .vs/
 

--- a/src/Nerdbank.Streams.Benchmark/BenchmarkConfig.cs
+++ b/src/Nerdbank.Streams.Benchmark/BenchmarkConfig.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace Nerdbank.Streams.Benchmark
+{
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Diagnosers;
+    using BenchmarkDotNet.Jobs;
+
+    internal class BenchmarkConfig : ManualConfig
+    {
+        public BenchmarkConfig()
+        {
+            this.Add(DefaultConfig.Instance.With(MemoryDiagnoser.Default));
+        }
+    }
+}

--- a/src/Nerdbank.Streams.Benchmark/Nerdbank.Streams.Benchmark.csproj
+++ b/src/Nerdbank.Streams.Benchmark/Nerdbank.Streams.Benchmark.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.2;net472</TargetFrameworks>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+    <CodeAnalysisRuleSet>Nerdbank.Streams.Benchmark.ruleset</CodeAnalysisRuleSet>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.11.4" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Nerdbank.Streams\Nerdbank.Streams.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Nerdbank.Streams.Benchmark/Nerdbank.Streams.Benchmark.ruleset
+++ b/src/Nerdbank.Streams.Benchmark/Nerdbank.Streams.Benchmark.ruleset
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Microsoft Managed Recommended Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects." ToolsVersion="10.0">
+  <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
+    <Name Resource="MinimumRecommendedRules_Name" />
+    <Description Resource="MinimumRecommendedRules_Description" />
+  </Localization>
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1001" Action="Warning" />
+    <Rule Id="CA1009" Action="Warning" />
+    <Rule Id="CA1016" Action="Warning" />
+    <Rule Id="CA1033" Action="Warning" />
+    <Rule Id="CA1049" Action="Warning" />
+    <Rule Id="CA1060" Action="Warning" />
+    <Rule Id="CA1061" Action="Warning" />
+    <Rule Id="CA1063" Action="Warning" />
+    <Rule Id="CA1065" Action="Warning" />
+    <Rule Id="CA1301" Action="Warning" />
+    <Rule Id="CA1400" Action="Warning" />
+    <Rule Id="CA1401" Action="Warning" />
+    <Rule Id="CA1403" Action="Warning" />
+    <Rule Id="CA1404" Action="Warning" />
+    <Rule Id="CA1405" Action="Warning" />
+    <Rule Id="CA1410" Action="Warning" />
+    <Rule Id="CA1415" Action="Warning" />
+    <Rule Id="CA1821" Action="Warning" />
+    <Rule Id="CA1900" Action="Warning" />
+    <Rule Id="CA1901" Action="Warning" />
+    <Rule Id="CA2002" Action="Warning" />
+    <Rule Id="CA2100" Action="Warning" />
+    <Rule Id="CA2101" Action="Warning" />
+    <Rule Id="CA2108" Action="Warning" />
+    <Rule Id="CA2111" Action="Warning" />
+    <Rule Id="CA2112" Action="Warning" />
+    <Rule Id="CA2114" Action="Warning" />
+    <Rule Id="CA2116" Action="Warning" />
+    <Rule Id="CA2117" Action="Warning" />
+    <Rule Id="CA2122" Action="Warning" />
+    <Rule Id="CA2123" Action="Warning" />
+    <Rule Id="CA2124" Action="Warning" />
+    <Rule Id="CA2126" Action="Warning" />
+    <Rule Id="CA2131" Action="Warning" />
+    <Rule Id="CA2132" Action="Warning" />
+    <Rule Id="CA2133" Action="Warning" />
+    <Rule Id="CA2134" Action="Warning" />
+    <Rule Id="CA2137" Action="Warning" />
+    <Rule Id="CA2138" Action="Warning" />
+    <Rule Id="CA2140" Action="Warning" />
+    <Rule Id="CA2141" Action="Warning" />
+    <Rule Id="CA2146" Action="Warning" />
+    <Rule Id="CA2147" Action="Warning" />
+    <Rule Id="CA2149" Action="Warning" />
+    <Rule Id="CA2200" Action="Warning" />
+    <Rule Id="CA2202" Action="Warning" />
+    <Rule Id="CA2207" Action="Warning" />
+    <Rule Id="CA2212" Action="Warning" />
+    <Rule Id="CA2213" Action="Warning" />
+    <Rule Id="CA2214" Action="Warning" />
+    <Rule Id="CA2216" Action="Warning" />
+    <Rule Id="CA2220" Action="Warning" />
+    <Rule Id="CA2229" Action="Warning" />
+    <Rule Id="CA2231" Action="Warning" />
+    <Rule Id="CA2232" Action="Warning" />
+    <Rule Id="CA2235" Action="Warning" />
+    <Rule Id="CA2236" Action="Warning" />
+    <Rule Id="CA2237" Action="Warning" />
+    <Rule Id="CA2238" Action="Warning" />
+    <Rule Id="CA2240" Action="Warning" />
+    <Rule Id="CA2241" Action="Warning" />
+    <Rule Id="CA2242" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1600" Action="Hidden" />
+  </Rules>
+</RuleSet>

--- a/src/Nerdbank.Streams.Benchmark/Program.cs
+++ b/src/Nerdbank.Streams.Benchmark/Program.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace Nerdbank.Streams.Benchmark
+{
+    using System;
+    using BenchmarkDotNet.Running;
+
+    internal class Program
+    {
+        private static void Main(string[] args)
+        {
+            var switcher = new BenchmarkSwitcher(new[]
+            {
+                typeof(SequenceBenchmark),
+            });
+            switcher.Run(args);
+        }
+    }
+}

--- a/src/Nerdbank.Streams.Benchmark/SequenceBenchmark.cs
+++ b/src/Nerdbank.Streams.Benchmark/SequenceBenchmark.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace Nerdbank.Streams.Benchmark
+{
+    using System;
+    using System.Buffers;
+    using System.Collections.Generic;
+    using System.Text;
+    using BenchmarkDotNet.Attributes;
+
+    public class SequenceBenchmark
+    {
+        [Benchmark]
+        public void OneSegment_GetMemory()
+        {
+            using (var sequence = new Sequence<byte>())
+            {
+                var mem = sequence.GetMemory(12);
+                sequence.Advance(4);
+                mem = sequence.GetMemory(8);
+                sequence.Advance(4);
+                var ros = sequence.AsReadOnlySequence;
+            }
+        }
+
+        [Benchmark]
+        public void OneSegment_GetSpan()
+        {
+            using (var sequence = new Sequence<byte>())
+            {
+                var span = sequence.GetSpan(12);
+                sequence.Advance(4);
+                span = sequence.GetSpan(8);
+                sequence.Advance(4);
+                var ros = sequence.AsReadOnlySequence;
+            }
+        }
+
+        [Benchmark]
+        public void MultiSegment_GetMemory()
+        {
+            using (var sequence = new Sequence<byte>())
+            {
+                var mem = sequence.GetMemory(12);
+                sequence.Advance(10);
+                mem = sequence.GetMemory(128);
+                sequence.Advance(120);
+                mem = sequence.GetMemory(256);
+                sequence.Advance(250);
+                var ros = sequence.AsReadOnlySequence;
+            }
+        }
+
+        [Benchmark]
+        public void MultiSegment_GetSpan()
+        {
+            using (var sequence = new Sequence<byte>())
+            {
+                var span = sequence.GetSpan(12);
+                sequence.Advance(10);
+                span = sequence.GetSpan(128);
+                sequence.Advance(120);
+                span = sequence.GetSpan(256);
+                sequence.Advance(250);
+                var ros = sequence.AsReadOnlySequence;
+            }
+        }
+    }
+}

--- a/src/Nerdbank.Streams.Benchmark/SequenceBenchmark.cs
+++ b/src/Nerdbank.Streams.Benchmark/SequenceBenchmark.cs
@@ -9,62 +9,57 @@ namespace Nerdbank.Streams.Benchmark
     using System.Text;
     using BenchmarkDotNet.Attributes;
 
+    [Config(typeof(BenchmarkConfig))]
     public class SequenceBenchmark
     {
+        private readonly Sequence<byte> sequence = new Sequence<byte>();
+
         [Benchmark]
         public void OneSegment_GetMemory()
         {
-            using (var sequence = new Sequence<byte>())
-            {
-                var mem = sequence.GetMemory(12);
-                sequence.Advance(4);
-                mem = sequence.GetMemory(8);
-                sequence.Advance(4);
-                var ros = sequence.AsReadOnlySequence;
-            }
+            var mem = this.sequence.GetMemory(12);
+            this.sequence.Advance(4);
+            mem = this.sequence.GetMemory(8);
+            this.sequence.Advance(4);
+            var ros = this.sequence.AsReadOnlySequence;
+            this.sequence.Reset();
         }
 
         [Benchmark]
         public void OneSegment_GetSpan()
         {
-            using (var sequence = new Sequence<byte>())
-            {
-                var span = sequence.GetSpan(12);
-                sequence.Advance(4);
-                span = sequence.GetSpan(8);
-                sequence.Advance(4);
-                var ros = sequence.AsReadOnlySequence;
-            }
+            var span = this.sequence.GetSpan(12);
+            this.sequence.Advance(4);
+            span = this.sequence.GetSpan(8);
+            this.sequence.Advance(4);
+            var ros = this.sequence.AsReadOnlySequence;
+            this.sequence.Reset();
         }
 
         [Benchmark]
         public void MultiSegment_GetMemory()
         {
-            using (var sequence = new Sequence<byte>())
-            {
-                var mem = sequence.GetMemory(12);
-                sequence.Advance(10);
-                mem = sequence.GetMemory(128);
-                sequence.Advance(120);
-                mem = sequence.GetMemory(256);
-                sequence.Advance(250);
-                var ros = sequence.AsReadOnlySequence;
-            }
+            var mem = this.sequence.GetMemory(12);
+            this.sequence.Advance(10);
+            mem = this.sequence.GetMemory(128);
+            this.sequence.Advance(120);
+            mem = this.sequence.GetMemory(256);
+            this.sequence.Advance(250);
+            var ros = this.sequence.AsReadOnlySequence;
+            this.sequence.Reset();
         }
 
         [Benchmark]
         public void MultiSegment_GetSpan()
         {
-            using (var sequence = new Sequence<byte>())
-            {
-                var span = sequence.GetSpan(12);
-                sequence.Advance(10);
-                span = sequence.GetSpan(128);
-                sequence.Advance(120);
-                span = sequence.GetSpan(256);
-                sequence.Advance(250);
-                var ros = sequence.AsReadOnlySequence;
-            }
+            var span = this.sequence.GetSpan(12);
+            this.sequence.Advance(10);
+            span = this.sequence.GetSpan(128);
+            this.sequence.Advance(120);
+            span = this.sequence.GetSpan(256);
+            this.sequence.Advance(250);
+            var ros = this.sequence.AsReadOnlySequence;
+            this.sequence.Reset();
         }
     }
 }

--- a/src/Nerdbank.Streams.Tests/SequenceTests.cs
+++ b/src/Nerdbank.Streams.Tests/SequenceTests.cs
@@ -323,17 +323,22 @@ public class SequenceTests : TestBase
         // use the mock pool so that we can predict the actual array size will not exceed what we ask for.
         var seq = new Sequence<int>(new MockPool<int>());
 
-        seq.GetSpan(10);
+        var span = seq.GetSpan(10);
+        Enumerable.Range(1, 10).ToArray().CopyTo(span);
         seq.Advance(10);
 
         seq.AdvanceTo(seq.AsReadOnlySequence.GetPosition(3));
 
-        seq.GetSpan(10);
+        span = seq.GetSpan(10);
+        Enumerable.Range(11, 10).ToArray().CopyTo(span);
         seq.Advance(10);
 
-        seq.GetSpan(10);
+        span = seq.GetSpan(10);
+        Enumerable.Range(21, 10).ToArray().CopyTo(span);
         seq.Advance(10);
 
+        this.Logger.WriteLine(string.Join(", ", seq.AsReadOnlySequence.ToArray()));
+        Assert.Equal(Enumerable.Range(4, 27), seq.AsReadOnlySequence.ToArray());
         Assert.Equal(10 - 3 + 10 + 10, seq.AsReadOnlySequence.Length);
     }
 

--- a/src/Nerdbank.Streams.sln
+++ b/src/Nerdbank.Streams.sln
@@ -25,6 +25,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Nerdbank.Streams.Interop.Te
 EndProject
 Project("{9092AA53-FB77-4645-B42D-1CCCA6BD08BD}") = "nerdbank-streams", "nerdbank-streams\nerdbank-streams.njsproj", "{9C64CF35-FD7C-4D57-B10A-5BD2F112B8D2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Nerdbank.Streams.Benchmark", "Nerdbank.Streams.Benchmark\Nerdbank.Streams.Benchmark.csproj", "{DD19E7F3-2D17-4B4F-9984-B1F422231FBF}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -49,6 +51,10 @@ Global
 		{35EC5994-B682-4FD9-8242-D6D3DEE78FDE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9C64CF35-FD7C-4D57-B10A-5BD2F112B8D2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9C64CF35-FD7C-4D57-B10A-5BD2F112B8D2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD19E7F3-2D17-4B4F-9984-B1F422231FBF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DD19E7F3-2D17-4B4F-9984-B1F422231FBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DD19E7F3-2D17-4B4F-9984-B1F422231FBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DD19E7F3-2D17-4B4F-9984-B1F422231FBF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Nerdbank.Streams/Sequence`1.cs
+++ b/src/Nerdbank.Streams/Sequence`1.cs
@@ -312,12 +312,24 @@ namespace Nerdbank.Streams
                 }
             }
 
+            /// <summary>
+            /// Gets the memory that has been allocated but not yet committed.
+            /// </summary>
             internal Memory<T> TrailingSlack => this.AvailableMemory.Slice(this.End);
 
+            /// <summary>
+            /// Gets the tracker for the underlying array for this segment, which can be used to recycle the array when we're disposed of.
+            /// </summary>
             internal IMemoryOwner<T> MemoryOwner { get; private set; }
 
-            internal Memory<T> AvailableMemory { get; private set; }
+            /// <summary>
+            /// Gets the full memory owned by the <see cref="MemoryOwner"/>.
+            /// </summary>
+            internal Memory<T> AvailableMemory => this.MemoryOwner?.Memory ?? default;
 
+            /// <summary>
+            /// Gets the number of elements that are committed in this segment.
+            /// </summary>
             internal int Length => this.End - this.Start;
 
             /// <summary>
@@ -330,22 +342,18 @@ namespace Nerdbank.Streams
                 get => this.AvailableMemory.Length - this.End;
             }
 
+            /// <summary>
+            /// Gets or sets the next segment in the singly linked list of segments.
+            /// </summary>
             internal new SequenceSegment Next
             {
                 get => (SequenceSegment)base.Next;
                 set => base.Next = value;
             }
 
-            internal void SetMemory(IMemoryOwner<T> memoryOwner)
-            {
-                this.SetMemory(memoryOwner, 0, memoryOwner.Memory.Length);
-            }
-
             internal void SetMemory(IMemoryOwner<T> memoryOwner, int start, int end)
             {
                 this.MemoryOwner = memoryOwner;
-
-                this.AvailableMemory = this.MemoryOwner.Memory;
 
                 this.RunningIndex = 0;
                 this.Start = start;
@@ -357,7 +365,6 @@ namespace Nerdbank.Streams
             {
                 this.MemoryOwner.Dispose();
                 this.MemoryOwner = null;
-                this.AvailableMemory = default;
 
                 this.Memory = default;
                 this.Next = null;

--- a/src/Nerdbank.Streams/Sequence`1.cs
+++ b/src/Nerdbank.Streams/Sequence`1.cs
@@ -8,6 +8,7 @@ namespace Nerdbank.Streams
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Diagnostics;
+    using System.Reflection;
     using System.Runtime.CompilerServices;
     using Microsoft;
 
@@ -126,9 +127,7 @@ namespace Nerdbank.Streams
             current = this.first;
             while (current != firstSegment)
             {
-                var next = current.Next;
-                current.ResetMemory();
-                current = next;
+                current = this.RecycleAndGetNext(current);
             }
 
             firstSegment.AdvanceTo(firstIndex);
@@ -151,51 +150,21 @@ namespace Nerdbank.Streams
         /// returned by a prior call to <see cref="GetMemory(int)"/>.
         /// </summary>
         /// <param name="count">The number of elements written into memory.</param>
-        public void Advance(int count)
-        {
-            Requires.Range(count >= 0, nameof(count));
-            this.last.End += count;
-        }
+        public void Advance(int count) => this.last.Advance(count);
 
         /// <summary>
         /// Gets writable memory that can be initialized and added to the sequence via a subsequent call to <see cref="Advance(int)"/>.
         /// </summary>
         /// <param name="sizeHint">The size of the memory required, or 0 to just get a convenient (non-empty) buffer.</param>
         /// <returns>The requested memory.</returns>
-        public Memory<T> GetMemory(int sizeHint)
-        {
-            Requires.Range(sizeHint >= 0, nameof(sizeHint));
-
-            if (sizeHint == 0)
-            {
-                if (this.last?.WritableBytes > 0)
-                {
-                    return this.last.TrailingSlack;
-                }
-                else
-                {
-                    sizeHint = -1; // MemoryPool<T>.Rent value for "give us the default size"
-                }
-            }
-            else
-            {
-                sizeHint = Math.Max(this.MinimumSpanLength, sizeHint);
-            }
-
-            if (this.last == null || this.last.WritableBytes < sizeHint)
-            {
-                this.Append(this.memoryPool.Rent(sizeHint));
-            }
-
-            return this.last.TrailingSlack;
-        }
+        public Memory<T> GetMemory(int sizeHint) => this.GetSegment(sizeHint).RemainingMemory;
 
         /// <summary>
         /// Gets writable memory that can be initialized and added to the sequence via a subsequent call to <see cref="Advance(int)"/>.
         /// </summary>
         /// <param name="sizeHint">The size of the memory required, or 0 to just get a convenient (non-empty) buffer.</param>
         /// <returns>The requested memory.</returns>
-        public Span<T> GetSpan(int sizeHint) => this.GetMemory(sizeHint).Span;
+        public Span<T> GetSpan(int sizeHint) => this.GetSegment(sizeHint).RemainingSpan;
 
         /// <summary>
         /// Clears the entire sequence, recycles associated memory into pools,
@@ -220,12 +189,35 @@ namespace Nerdbank.Streams
             this.first = this.last = null;
         }
 
-        private void Append(IMemoryOwner<T> array)
+        private SequenceSegment GetSegment(int sizeHint)
         {
-            Requires.NotNull(array, nameof(array));
+            Requires.Range(sizeHint >= 0, nameof(sizeHint));
+            if (sizeHint == 0)
+            {
+                if (this.last == null || this.last.WritableBytes == 0)
+                {
+                    // We're going to need more memory. Take whatever size the pool wants to give us.
+                    this.Append(this.memoryPool.Rent());
+                }
+            }
+            else
+            {
+                sizeHint = Math.Max(this.MinimumSpanLength, sizeHint);
+                if (this.last == null || this.last.WritableBytes < sizeHint)
+                {
+                    this.Append(this.memoryPool.Rent(sizeHint));
+                }
+            }
+
+            return this.last;
+        }
+
+        private void Append(IMemoryOwner<T> memoryOwner)
+        {
+            Requires.NotNull(memoryOwner, nameof(memoryOwner));
 
             var segment = this.segmentPool.Count > 0 ? this.segmentPool.Pop() : new SequenceSegment();
-            segment.SetMemory(array, 0, 0);
+            segment.Assign(memoryOwner);
 
             if (this.last == null)
             {
@@ -274,48 +266,25 @@ namespace Nerdbank.Streams
         private class SequenceSegment : ReadOnlySequenceSegment<T>
         {
             /// <summary>
-            /// Backing field for the <see cref="End"/> property.
+            /// Gets the position within <see cref="ReadOnlySequenceSegment{T}.Memory"/> where the data starts.
             /// </summary>
-            private int end;
-
-            /// <summary>
-            /// Gets the index of the first element in <see cref="AvailableMemory"/> to consider part of the sequence.
-            /// </summary>
-            /// <remarks>
-            /// The <see cref="Start"/> represents the offset into <see cref="AvailableMemory"/> where the range of "active" bytes begins. At the point when the block is leased
-            /// the <see cref="Start"/> is guaranteed to be equal to 0. The value of <see cref="Start"/> may be assigned anywhere between 0 and
-            /// <see cref="AvailableMemory"/>.Length, and must be equal to or less than <see cref="End"/>.
-            /// </remarks>
+            /// <remarks>This may be nonzero as a result of calling <see cref="Sequence{T}.AdvanceTo(SequencePosition)"/>.</remarks>
             internal int Start { get; private set; }
 
             /// <summary>
-            /// Gets or sets the index of the element just beyond the end in <see cref="AvailableMemory"/> to consider part of the sequence.
+            /// Gets the position within <see cref="ReadOnlySequenceSegment{T}.Memory"/> where the data ends.
             /// </summary>
-            /// <remarks>
-            /// The <see cref="End"/> represents the offset into <see cref="AvailableMemory"/> where the range of "active" bytes ends. At the point when the block is leased
-            /// the <see cref="End"/> is guaranteed to be equal to <see cref="Start"/>. The value of <see cref="Start"/> may be assigned anywhere between 0 and
-            /// <see cref="AvailableMemory"/>.Length, and must be equal to or less than <see cref="End"/>.
-            /// </remarks>
-            internal int End
-            {
-                get => this.end;
-                set
-                {
-                    Requires.Range(value <= this.AvailableMemory.Length, nameof(value));
-
-                    this.end = value;
-
-                    // If we ever support creating these instances on existing arrays, such that
-                    // this.Start isn't 0 at the beginning, we'll have to "pin" this.Start and remove
-                    // Advance, forcing Sequence<T> itself to track it, the way Pipe does it internally.
-                    this.Memory = this.AvailableMemory.Slice(0, value);
-                }
-            }
+            internal int End { get; private set; }
 
             /// <summary>
-            /// Gets the memory that has been allocated but not yet committed.
+            /// Gets the tail of memory that has not yet been committed.
             /// </summary>
-            internal Memory<T> TrailingSlack => this.AvailableMemory.Slice(this.End);
+            internal Memory<T> RemainingMemory => this.MemoryOwner.Memory.Slice(this.End);
+
+            /// <summary>
+            /// Gets the tail of memory that has not yet been committed.
+            /// </summary>
+            internal Span<T> RemainingSpan => this.MemoryOwner.Memory.Span.Slice(this.End);
 
             /// <summary>
             /// Gets the tracker for the underlying array for this segment, which can be used to recycle the array when we're disposed of.
@@ -336,11 +305,7 @@ namespace Nerdbank.Streams
             /// Gets the amount of writable bytes in this segment.
             /// It is the amount of bytes between <see cref="Length"/> and <see cref="End"/>.
             /// </summary>
-            internal int WritableBytes
-            {
-                [MethodImpl(MethodImplOptions.AggressiveInlining)]
-                get => this.AvailableMemory.Length - this.End;
-            }
+            internal int WritableBytes => this.AvailableMemory.Length - this.End;
 
             /// <summary>
             /// Gets or sets the next segment in the singly linked list of segments.
@@ -351,38 +316,68 @@ namespace Nerdbank.Streams
                 set => base.Next = value;
             }
 
-            internal void SetMemory(IMemoryOwner<T> memoryOwner, int start, int end)
+            /// <summary>
+            /// Assigns this (recyclable) segment a new area in memory.
+            /// </summary>
+            /// <param name="memoryOwner">The memory and a means to recycle it.</param>
+            internal void Assign(IMemoryOwner<T> memoryOwner)
             {
                 this.MemoryOwner = memoryOwner;
-
-                this.RunningIndex = 0;
-                this.Start = start;
-                this.End = end;
-                this.Next = null;
+                this.Memory = memoryOwner.Memory;
             }
 
+            /// <summary>
+            /// Clears all fields in preparation to recycle this instance.
+            /// </summary>
             internal void ResetMemory()
             {
-                this.MemoryOwner.Dispose();
-                this.MemoryOwner = null;
-
                 this.Memory = default;
                 this.Next = null;
+                this.RunningIndex = 0;
                 this.Start = 0;
-                this.end = 0;
+                this.End = 0;
+                this.MemoryOwner.Dispose();
+                this.MemoryOwner = null;
             }
 
+            /// <summary>
+            /// Adds a new segment after this one.
+            /// </summary>
+            /// <param name="segment">The next segment in the linked list.</param>
             internal void SetNext(SequenceSegment segment)
             {
-                Requires.NotNull(segment, nameof(segment));
-
+                Debug.Assert(segment != null, "Null not allowed.");
                 this.Next = segment;
-                segment.RunningIndex = this.RunningIndex + this.End;
+                segment.RunningIndex = this.RunningIndex + this.Start + this.Length;
+
+                // When setting Memory, we start with index 0 instead of this.Start because
+                // the first segment has an explicit index set anyway,
+                // and we don't want to double-count it here.
+                this.Memory = this.AvailableMemory.Slice(0, this.Start + this.Length);
             }
 
+            /// <summary>
+            /// Commits more elements as written in this segment.
+            /// </summary>
+            /// <param name="count">The number of elements written.</param>
+            internal void Advance(int count)
+            {
+                Requires.Range(count >= 0 && this.End + count <= this.Memory.Length, nameof(count));
+                this.End += count;
+            }
+
+            /// <summary>
+            /// Removes some elements from the start of this segment.
+            /// </summary>
+            /// <param name="offset">The number of elements to remove.</param>
             internal void AdvanceTo(int offset)
             {
-                Requires.Range(offset <= this.End, nameof(offset));
+                // If we store references, clear them to allow the objects to be GC'd.
+                if (!typeof(T).GetTypeInfo().IsValueType)
+                {
+                    this.AvailableMemory.Span.Slice(this.Start, offset).Fill(default);
+                }
+
                 this.Start = offset;
             }
         }


### PR DESCRIPTION
This improves `Sequence<T>` performance by 24-33%. And more wins may be possible with a fix for #51.

Closes #53