### PR TITLE
Add support for ArrayPool<T> to Sequence<T>

### DIFF
--- a/src/Nerdbank.Streams.Tests/MockArrayPool`1.cs
+++ b/src/Nerdbank.Streams.Tests/MockArrayPool`1.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft;
+using Xunit;
+
+internal class MockArrayPool<T> : ArrayPool<T>
+{
+    internal const int DefaultLength = 16;
+
+    public List<T[]> Contents { get; } = new List<T[]>();
+
+    /// <summary>
+    /// Gets or sets a multiplying factor for how much larger the minimum size of array returned
+    /// should be relative to the actual requested size.
+    /// </summary>
+    public double MinArraySizeFactor { get; set; } = 1.0;
+
+    public override T[] Rent(int minBufferSize)
+    {
+        Requires.Range(minBufferSize >= 0, nameof(minBufferSize));
+
+        if (minBufferSize == 0)
+        {
+            return Array.Empty<T>();
+        }
+
+        minBufferSize = (int)(minBufferSize * this.MinArraySizeFactor);
+        T[] result = this.Contents.FirstOrDefault(a => a.Length >= minBufferSize);
+
+        if (result == null)
+        {
+            result = new T[minBufferSize == -1 ? DefaultLength : minBufferSize];
+        }
+        else
+        {
+            this.Contents.Remove(result);
+        }
+
+        return result;
+    }
+
+    public override void Return(T[] array, bool clearArray = false)
+    {
+        if (clearArray)
+        {
+            Array.Clear(array, 0, array.Length);
+        }
+
+        this.Contents.Add(array);
+    }
+
+    internal void AssertContents(params T[][] expectedArrays) => this.AssertContents((IEnumerable<T[]>)expectedArrays);
+
+    internal void AssertContents(IEnumerable<T[]> expectedArrays)
+    {
+        Assert.Equal(expectedArrays, this.Contents);
+    }
+}

--- a/src/Nerdbank.Streams.Tests/MockMemoryPool`1.cs
+++ b/src/Nerdbank.Streams.Tests/MockMemoryPool`1.cs
@@ -7,7 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Xunit;
 
-internal class MockPool<T> : MemoryPool<T>
+internal class MockMemoryPool<T> : MemoryPool<T>
 {
     internal const int DefaultLength = 16;
 
@@ -76,9 +76,9 @@ internal class MockPool<T> : MemoryPool<T>
 
     private class Rental : IMemoryOwner<T>
     {
-        private readonly MockPool<T> owner;
+        private readonly MockMemoryPool<T> owner;
 
-        internal Rental(MockPool<T> owner, Memory<T> memory)
+        internal Rental(MockMemoryPool<T> owner, Memory<T> memory)
         {
             this.owner = owner ?? throw new ArgumentNullException(nameof(owner));
             this.Memory = memory;

--- a/src/Nerdbank.Streams.Tests/PrefixingBufferWriterTests.cs
+++ b/src/Nerdbank.Streams.Tests/PrefixingBufferWriterTests.cs
@@ -16,7 +16,7 @@ public class PrefixingBufferWriterTests
 
     private static readonly ReadOnlyMemory<byte> Payload = Enumerable.Range(3, PayloadSize).Select(v => (byte)v).ToArray();
 
-    private readonly MockPool<byte> mockPool = new MockPool<byte>();
+    private readonly MockMemoryPool<byte> mockPool = new MockMemoryPool<byte>();
 
     private readonly Sequence<byte> sequence;
 


### PR DESCRIPTION
This is the new default.
It reduces GC pressure since renting arrays no longer incurs an IMemoryOwner<T> allocation.
It also improves performance significantly: 14-32%

Closes #51