### PR TITLE
Add BufferTextWriter and SequenceTextReader

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,9 @@ Specialized .NET Stream classes
 1. [`Sequence<T>`](doc/Sequence.md) is a builder for `ReadOnlySequence<T>`.
 1. [`PrefixingBufferWriter<T>`](doc/PrefixingBufferWriter.md) wraps another `IBufferWriter<T>`
    to allow for prefixing some header to the next written buffer, which may be arbitrarily long.
+1. [`BufferTextWriter`](doc/BufferTextWriter.md) is a `TextWriter`-derived type that can
+   write directly to any `IBufferWriter<byte>`, making it more reusable than `StreamWriter`
+   and thus allows for alloc-free writing across many writers.
+1. [`SequenceTextReader`](doc/SequenceTextReader.md) is a `TextReader`-derived type that can
+   read directly from any `ReadOnlySequence<byte>`, making it more reusable than `StreamReader`
+   and thus allows for alloc-free reading across many sequences.

--- a/doc/BufferTextWriter.md
+++ b/doc/BufferTextWriter.md
@@ -1,0 +1,35 @@
+# `TextWriter` for `IBufferWriter<byte>` 
+
+Given an `IBufferWriter<byte>`, an adapter to progressively write text to it
+can be useful. Many APIs already accept a `TextWriter` to write text to.
+`Console.Out` and `StreamWriter` are `TextWriter`s, for example.
+
+The `BufferTextWriter` class derives from `TextWriter` and accepts an
+`IBufferWriter<byte>` in order to enable writing text to a byte buffer or stream.
+
+You can also use the [`IBufferWriter<byte>.AsStream()`](AsStream.md) extension method to create a `Stream`
+and pass that as an argument when constructing a new `StreamWriter`, but creating a `StreamWriter`
+allocates a couple of large `byte[]` and `char[]` arrays which make this an expensive approach,
+particularly when you need to read from many unique `IBufferWriter<byte>` instances and thus
+have to repeatedly create a new `StreamWriter` and its own buffers each time.
+
+`BufferTextWriter` avoids these costs by optimizing for reading directly from the
+`IBufferWriter<byte>` (avoiding the `Stream` intermediate adapter) and by allowing
+the same `BufferTextWriter` instance to be assigned different `IBufferWriter<byte>`
+over time, allowing reuse of the buffers it uses internally during the encoding process.
+
+## Example
+
+```cs
+private readonly BufferTextWriter textWriter = new BufferTextWriter();
+
+void ReadTextFromConsole(IBufferWriter<byte> byteWriter)
+{
+    textWriter.Initialize(byteWriter, Encoding.UTF8);
+    string line;
+    while ((line = Console.In.ReadLine()) != null)
+    {
+        textWriter.WriteLine(line);
+    }
+}
+```

--- a/doc/SequenceTextReader.md
+++ b/doc/SequenceTextReader.md
@@ -1,0 +1,35 @@
+# `TextReader` for `ReadOnlySequence<byte>`
+
+Given a `ReadOnlySequence<byte>`, an adapter to progressively read it as text
+can be useful. Many APIs already accept a `TextReader` to read text.
+`Console.In` and `StreamReader` are `TextReader`s, for example.
+
+The `SequenceTextReader` class derives from `TextReader` and accepts a
+`ReadOnlySequence<byte>` in order to enable reading text from a byte sequence.
+
+You can also use the [`ReadOnlySequence<byte>.AsStream()`](AsStream.md) extension method to create a `Stream`
+and pass that as an argument when constructing a new `StreamReader`, but creating a `StreamReader`
+allocates a couple of large `byte[]` and `char[]` arrays which make this an expensive approach,
+particularly when you need to read from many unique `ReadOnlySequence<byte>` instances and thus
+have to repeatedly create a new `StreamReader` and its own buffers each time.
+
+`SequenceTextReader` avoids these costs by optimizing for reading directly from the
+`ReadOnlySequence<byte>` (avoiding the `Stream` intermediate adapter) and by allowing
+the same `SequenceTextReader` instance to be assigned different `ReadOnlySequence<byte>`
+over time, allowing reuse of the buffers it uses internally during the decoding process.
+
+## Example
+
+```cs
+private readonly SequenceTextReader sequenceReader = new SequenceTextReader();
+
+void PrintTextToConsole(ReadOnlySequence<byte> sequence)
+{
+    sequenceReader.Initialize(sequence, Encoding.UTF8);
+    string line;
+    while ((line = sequenceReader.ReadLine()) != null)
+    {
+        Console.WriteLine(line);
+    }
+}
+```

--- a/src/Nerdbank.Streams.Tests/BufferTextWriterTests.cs
+++ b/src/Nerdbank.Streams.Tests/BufferTextWriterTests.cs
@@ -1,0 +1,166 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nerdbank.Streams;
+using Xunit;
+using Xunit.Abstractions;
+
+public class BufferTextWriterTests : TestBase
+{
+    private static readonly Encoding DefaultEncoding = Encoding.UTF8;
+    private static readonly Encoding DefaultEncodingNoPreamble = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+    private BufferTextWriter bufferTextWriter = new BufferTextWriter();
+    private Sequence<byte> sequence = new Sequence<byte>();
+
+    public BufferTextWriterTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        Assert.Null(this.bufferTextWriter.Encoding);
+        this.bufferTextWriter.Initialize(this.sequence, DefaultEncoding);
+    }
+
+    [Fact]
+    public void Ctor_ValidatesArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() => new BufferTextWriter(null, DefaultEncoding));
+        Assert.Throws<ArgumentNullException>(() => new BufferTextWriter(this.sequence, null));
+    }
+
+    [Fact]
+    public void Ctor()
+    {
+        this.bufferTextWriter = new BufferTextWriter(this.sequence, DefaultEncoding);
+        Assert.Same(DefaultEncoding, this.bufferTextWriter.Encoding);
+        this.bufferTextWriter.Write('a');
+        this.AssertWritten("a");
+    }
+
+    [Fact]
+    public void Initialize_ValidatesArgs()
+    {
+        Assert.Throws<ArgumentNullException>(() => this.bufferTextWriter.Initialize(new Sequence<byte>(), null));
+        Assert.Throws<ArgumentNullException>(() => this.bufferTextWriter.Initialize(null, Encoding.UTF8));
+    }
+
+    [Fact]
+    public void Initialize_ThrowsIfUnflushed()
+    {
+        this.bufferTextWriter.Write("hi");
+        Assert.Throws<InvalidOperationException>(() => this.bufferTextWriter.Initialize(new Sequence<byte>(), DefaultEncoding));
+    }
+
+    [Fact]
+    public void Initialize_SameEncoder()
+    {
+        this.bufferTextWriter.Initialize(new Sequence<byte>(), this.bufferTextWriter.Encoding);
+    }
+
+    [Fact]
+    public void Encoding_AfterInitialize()
+    {
+        this.bufferTextWriter.Initialize(new Sequence<byte>(), Encoding.Unicode);
+        Assert.Same(Encoding.Unicode, this.bufferTextWriter.Encoding);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Anything_Uninitialized(bool afterReset)
+    {
+        BufferTextWriter writer;
+        if (afterReset)
+        {
+            writer = this.bufferTextWriter;
+            writer.Reset();
+        }
+        else
+        {
+            writer = new BufferTextWriter();
+        }
+
+        Assert.Throws<InvalidOperationException>(() => writer.Flush());
+        Assert.IsType<InvalidOperationException>(writer.FlushAsync().Exception?.InnerException);
+        Assert.Throws<InvalidOperationException>(() => writer.Write(true));
+        Assert.Throws<InvalidOperationException>(() => writer.Write('a'));
+        Assert.Throws<InvalidOperationException>(() => writer.Write("a"));
+    }
+
+    [Fact]
+    public void Write_Bool()
+    {
+        this.bufferTextWriter.Write(true);
+        this.AssertWritten("True");
+    }
+
+    [Fact]
+    public void Write_Char()
+    {
+        this.bufferTextWriter.Write('a');
+        this.AssertWritten("a");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(3)]
+    [InlineData(300)]
+    [InlineData(30000)]
+    public void Write_String(int length)
+    {
+        string written = new string('a', length);
+        this.bufferTextWriter.Write(written);
+        this.AssertWritten(written);
+    }
+
+    [Fact]
+    public void Write_String_Null()
+    {
+        this.bufferTextWriter.Write((string)null);
+        this.AssertWritten(string.Empty);
+    }
+
+    [Fact]
+    public void Write_CharThenLongString()
+    {
+        string longString = new string('b', 10000);
+        this.bufferTextWriter.Write('a');
+        this.bufferTextWriter.Write(longString);
+        this.AssertWritten('a' + longString);
+    }
+
+    [Fact]
+    public void FlushAsync_CompletesSynchronously()
+    {
+        this.bufferTextWriter.Initialize(this.sequence, DefaultEncodingNoPreamble);
+        this.bufferTextWriter.Write('b');
+        Assert.Equal(TaskStatus.RanToCompletion, this.bufferTextWriter.FlushAsync().Status);
+        Assert.Equal(DefaultEncodingNoPreamble.GetBytes("b"), this.sequence.AsReadOnlySequence.ToArray());
+    }
+
+    private void AssertWritten(string expected, Encoding encoding = null)
+    {
+        encoding = encoding ?? DefaultEncoding;
+        this.bufferTextWriter.Flush();
+
+        if (expected.Length == 0)
+        {
+            Assert.Equal(0, this.sequence.Length);
+            return;
+        }
+
+        byte[] writtenBytes = this.sequence.AsReadOnlySequence.ToArray();
+
+        // Assert the preamble was written, if any.
+        var expectedPreamble = encoding.GetPreamble();
+        Assert.Equal(expectedPreamble, writtenBytes.Take(expectedPreamble.Length));
+
+        // Skip the preamble when comparing the string.
+        Assert.Equal(expected, encoding.GetString(writtenBytes, expectedPreamble.Length, writtenBytes.Length - expectedPreamble.Length));
+    }
+}

--- a/src/Nerdbank.Streams.Tests/SequenceTextReaderTests.cs
+++ b/src/Nerdbank.Streams.Tests/SequenceTextReaderTests.cs
@@ -1,0 +1,224 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Nerdbank.Streams;
+using Xunit;
+using Xunit.Abstractions;
+
+public class SequenceTextReaderTests : TestBase
+{
+    private const string CharactersToRead = "ABCDEFG\r\nabcdefg\n1234567890";
+    private static readonly Encoding DefaultEncoding = Encoding.UTF8;
+    private readonly SequenceTextReader sequenceTextReader = new SequenceTextReader();
+    private readonly TextReader baselineReader = new StringReader(CharactersToRead);
+
+    public SequenceTextReaderTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        var ros = new ReadOnlySequence<byte>(DefaultEncoding.GetBytes(CharactersToRead));
+        this.sequenceTextReader.Initialize(ros, DefaultEncoding);
+    }
+
+    [Fact]
+    public void Ctor_ValidatesArguments()
+    {
+        Assert.Throws<ArgumentNullException>(() => new SequenceTextReader(default, null));
+    }
+
+    [Fact]
+    public void Ctor()
+    {
+        var reader = new SequenceTextReader(default, DefaultEncoding);
+        Assert.Equal(-1, reader.Read());
+
+        var ros = new ReadOnlySequence<byte>(DefaultEncoding.GetBytes(CharactersToRead));
+        reader = new SequenceTextReader(ros, DefaultEncoding);
+        Assert.Equal('A', reader.Read());
+    }
+
+    [Fact]
+    public void Initialize_ValidatesArgs()
+    {
+        Assert.Throws<ArgumentNullException>(() => this.sequenceTextReader.Initialize(default, null));
+    }
+
+    [Fact]
+    public void Read_SkipsPreamble()
+    {
+        byte[] preamble = Encoding.UTF8.GetPreamble();
+        byte[] bodyBytes = Encoding.UTF8.GetBytes("a");
+        byte[] preambleAndBody = preamble.Concat(bodyBytes).ToArray();
+        this.sequenceTextReader.Initialize(new ReadOnlySequence<byte>(preambleAndBody), Encoding.UTF8);
+        Assert.Equal('a', this.sequenceTextReader.Read());
+        Assert.Equal(-1, this.sequenceTextReader.Read());
+    }
+
+    [Fact]
+    public void Read_SkipsPreamble_NoBody()
+    {
+        byte[] preamble = Encoding.UTF8.GetPreamble();
+        this.sequenceTextReader.Initialize(new ReadOnlySequence<byte>(preamble), Encoding.UTF8);
+        Assert.Equal(-1, this.sequenceTextReader.Read());
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void Anything_Uninitialized(bool afterReset)
+    {
+        SequenceTextReader reader;
+        if (afterReset)
+        {
+            reader = this.sequenceTextReader;
+            reader.Reset();
+        }
+        else
+        {
+            reader = new SequenceTextReader();
+        }
+
+        Assert.Equal(-1, reader.Peek());
+        Assert.Equal(-1, reader.Read());
+        Assert.Null(reader.ReadLine());
+        Assert.Equal(string.Empty, reader.ReadToEnd());
+    }
+
+    [Fact]
+    public void Read()
+    {
+        int actual, expected;
+        do
+        {
+            actual = this.sequenceTextReader.Read();
+            expected = this.baselineReader.Read();
+            Assert.Equal(expected, actual);
+        }
+        while (actual != -1);
+    }
+
+    [Fact]
+    public void PeekAndRead()
+    {
+        int actual, expected;
+        do
+        {
+            actual = this.sequenceTextReader.Peek();
+            expected = this.baselineReader.Peek();
+            Assert.Equal(expected, actual);
+
+            actual = this.sequenceTextReader.Read();
+            expected = this.baselineReader.Read();
+            Assert.Equal(expected, actual);
+        }
+        while (actual != -1);
+    }
+
+    [Fact]
+    public void ReadToEnd()
+    {
+        Assert.Equal(this.baselineReader.ReadToEnd(), this.sequenceTextReader.ReadToEnd());
+    }
+
+    [Fact]
+    public void ReadLine()
+    {
+        string actual, expected;
+        do
+        {
+            actual = this.sequenceTextReader.ReadLine();
+            expected = this.baselineReader.ReadLine();
+            Assert.Equal(expected, actual);
+        }
+        while (actual != null);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(0, 1)]
+    [InlineData(2, 1)]
+    public void ReadBlock(int bufferOffset, int bufferSlack)
+    {
+        const int BlockLength = 5;
+        char[] actualBlock = new char[BlockLength], expectedBlock = new char[BlockLength];
+        int actualResult, expectedResult;
+        do
+        {
+            actualResult = this.sequenceTextReader.ReadBlock(actualBlock, bufferOffset, BlockLength - bufferOffset - bufferSlack);
+            expectedResult = this.baselineReader.ReadBlock(expectedBlock, bufferOffset, BlockLength - bufferOffset - bufferSlack);
+            Assert.Equal(expectedResult, actualResult);
+        }
+        while (actualResult > 0);
+    }
+
+    [Theory]
+    [InlineData(0, 0)]
+    [InlineData(1, 0)]
+    [InlineData(0, 1)]
+    [InlineData(2, 1)]
+    public void Read_Buffer(int bufferOffset, int bufferSlack)
+    {
+        const int BlockLength = 5;
+        char[] actualBlock = new char[BlockLength], expectedBlock = new char[BlockLength];
+        int actualResult, expectedResult;
+        do
+        {
+            actualResult = this.sequenceTextReader.Read(actualBlock, bufferOffset, BlockLength - bufferOffset - bufferSlack);
+            expectedResult = this.baselineReader.Read(expectedBlock, bufferOffset, BlockLength - bufferOffset - bufferSlack);
+            Assert.Equal(expectedResult, actualResult);
+        }
+        while (actualResult > 0);
+    }
+
+    [Fact]
+    public void Read_Buffer_Empty()
+    {
+        Assert.Equal(0, this.sequenceTextReader.Read(new char[0], 0, 0));
+        Assert.Equal(0, this.sequenceTextReader.Read(new char[1], 1, 0));
+    }
+
+    [Fact]
+    public void Read_Buffer_InvalidInputs()
+    {
+        Assert.Throws<ArgumentNullException>(() => this.sequenceTextReader.Read(null, 0, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => this.sequenceTextReader.Read(new char[2], 0, -1));
+        Assert.Throws<ArgumentOutOfRangeException>(() => this.sequenceTextReader.Read(new char[2], -1, 2));
+        Assert.Throws<ArgumentException>(() => this.sequenceTextReader.Read(new char[2], 0, 3));
+        Assert.Throws<ArgumentException>(() => this.sequenceTextReader.Read(new char[2], 2, 1));
+        Assert.Throws<ArgumentException>(() => this.sequenceTextReader.Read(new char[2], 3, 1));
+        Assert.Throws<ArgumentException>(() => this.sequenceTextReader.Read(new char[2], 3, 0));
+    }
+
+    [Fact]
+    public void Read_VeryLarge()
+    {
+        var smallBytes = DefaultEncoding.GetBytes(CharactersToRead);
+        var bytes = new byte[30000];
+        for (int i = 0; i < bytes.Length; i += smallBytes.Length)
+        {
+            Buffer.BlockCopy(smallBytes, 0, bytes, i, Math.Min(bytes.Length - i, smallBytes.Length));
+        }
+
+        this.sequenceTextReader.Initialize(new ReadOnlySequence<byte>(bytes), DefaultEncoding);
+
+        const int BlockLength = 49;
+        char[] actualBlock = new char[BlockLength];
+        char[] expectedBlock = DefaultEncoding.GetChars(bytes);
+        int totalCharsRead = 0;
+        int charsRead;
+        do
+        {
+            charsRead = this.sequenceTextReader.Read(actualBlock, 0, BlockLength);
+            Assert.Equal(expectedBlock.Skip(totalCharsRead).Take(charsRead), actualBlock.Take(charsRead));
+            totalCharsRead += charsRead;
+        }
+        while (charsRead > 0);
+    }
+}

--- a/src/Nerdbank.Streams/BufferTextWriter.cs
+++ b/src/Nerdbank.Streams/BufferTextWriter.cs
@@ -1,0 +1,317 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace Nerdbank.Streams
+{
+    using System;
+    using System.Buffers;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Runtime.InteropServices;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft;
+
+    /// <summary>
+    /// A <see cref="TextWriter"/> that writes to a reassignable instance of <see cref="IBufferWriter{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// Using this is much more memory efficient than a <see cref="StreamWriter"/> when writing to many different
+    /// <see cref="IBufferWriter{T}"/> because the same writer, with all its buffers, can be reused.
+    /// </remarks>
+    public class BufferTextWriter : TextWriter
+    {
+        /// <summary>
+        /// A buffer of written characters that have not yet been encoded.
+        /// The <see cref="charBufferPosition"/> field tracks how many characters are represented in this buffer.
+        /// </summary>
+        private readonly char[] charBuffer = new char[512];
+
+        /// <summary>
+        /// The internal buffer writer to use for writing encoded characters.
+        /// </summary>
+        private IBufferWriter<byte> bufferWriter;
+
+        /// <summary>
+        /// The last buffer received from <see cref="bufferWriter"/>.
+        /// </summary>
+        private Memory<byte> memory;
+
+        /// <summary>
+        /// The number of characters written to the <see cref="memory"/> buffer.
+        /// </summary>
+        private int memoryPosition;
+
+        /// <summary>
+        /// The number of characters written to the <see cref="charBuffer"/>.
+        /// </summary>
+        private int charBufferPosition;
+
+        /// <summary>
+        /// Whether the encoding preamble has been written since the last call to <see cref="Initialize(IBufferWriter{byte}, Encoding)"/>.
+        /// </summary>
+        private bool preambleWritten;
+
+        /// <summary>
+        /// The encoding currently in use.
+        /// </summary>
+        private Encoding encoding;
+
+        /// <summary>
+        /// The preamble for the current <see cref="encoding"/>.
+        /// </summary>
+        /// <remarks>
+        /// We store this as a field to avoid calling <see cref="Encoding.GetPreamble"/> repeatedly,
+        /// since the typical implementation allocates a new array for each call.
+        /// </remarks>
+        private ReadOnlyMemory<byte> encodingPreamble;
+
+        /// <summary>
+        /// An encoder obtained from the current <see cref="encoding"/> used for incrementally encoding written characters.
+        /// </summary>
+        private Encoder encoder;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BufferTextWriter"/> class.
+        /// </summary>
+        /// <remarks>
+        /// When using this constructor, call <see cref="Initialize(IBufferWriter{byte}, Encoding)"/>
+        /// to associate the instance with the initial writer to use before using any write or flush methods.
+        /// </remarks>
+        public BufferTextWriter()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="BufferTextWriter"/> class.
+        /// </summary>
+        /// <param name="bufferWriter">The buffer writer to write to.</param>
+        /// <param name="encoding">The encoding to use.</param>
+        public BufferTextWriter(IBufferWriter<byte> bufferWriter, Encoding encoding)
+        {
+            this.Initialize(bufferWriter, encoding);
+        }
+
+        /// <inheritdoc />
+        public override Encoding Encoding => this.encoding;
+
+        /// <summary>
+        /// Gets the number of uninitialized characters remaining in <see cref="charBuffer"/>.
+        /// </summary>
+        private int CharBufferSlack => this.charBuffer.Length - this.charBufferPosition;
+
+        /// <summary>
+        /// Prepares for writing to the specified buffer.
+        /// </summary>
+        /// <param name="bufferWriter">The buffer writer to write to.</param>
+        /// <param name="encoding">The encoding to use.</param>
+        public void Initialize(IBufferWriter<byte> bufferWriter, Encoding encoding)
+        {
+            Requires.NotNull(bufferWriter, nameof(bufferWriter));
+            Requires.NotNull(encoding, nameof(encoding));
+
+            Verify.Operation(this.memoryPosition == 0 && this.charBufferPosition == 0, "This instance must be flushed before being reinitialized.");
+
+            this.preambleWritten = false;
+            this.bufferWriter = bufferWriter;
+            if (encoding != this.encoding)
+            {
+                this.encoding = encoding;
+                this.encoder = this.encoding.GetEncoder();
+                this.encodingPreamble = this.encoding.GetPreamble();
+            }
+            else
+            {
+                this.encoder.Reset();
+            }
+        }
+
+        /// <summary>
+        /// Clears references to the <see cref="IBufferWriter{T}"/> set by a prior call to <see cref="Initialize(IBufferWriter{byte}, Encoding)"/>.
+        /// </summary>
+        public void Reset()
+        {
+            this.bufferWriter = null;
+        }
+
+        /// <inheritdoc />
+        public override void Flush()
+        {
+            this.ThrowIfNotInitialized();
+            this.EncodeCharacters(flushEncoder: true);
+            this.CommitBytes();
+        }
+
+        /// <inheritdoc />
+        public override Task FlushAsync()
+        {
+            try
+            {
+                this.Flush();
+                return Task.CompletedTask;
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException(ex);
+            }
+        }
+
+        /// <inheritdoc />
+        public override void Write(char value)
+        {
+            this.ThrowIfNotInitialized();
+            this.charBuffer[this.charBufferPosition++] = value;
+            this.EncodeCharactersIfBufferFull();
+        }
+
+        /// <inheritdoc />
+        public override void Write(string value)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            this.Write(value.AsSpan());
+        }
+
+        /// <inheritdoc />
+        public override void Write(char[] buffer, int index, int count) => this.Write(Requires.NotNull(buffer, nameof(buffer)).AsSpan(index, count));
+
+#if SPAN_BUILTIN
+        /// <inheritdoc />
+        public override void Write(ReadOnlySpan<char> buffer)
+#else
+        /// <summary>
+        /// Copies a given span of characters into the writer.
+        /// </summary>
+        /// <param name="buffer">The characters to write.</param>
+        public virtual void Write(ReadOnlySpan<char> buffer)
+#endif
+        {
+            this.ThrowIfNotInitialized();
+
+            // Try for fast path
+            if (buffer.Length <= this.CharBufferSlack)
+            {
+                buffer.CopyTo(this.charBuffer.AsSpan(this.charBufferPosition));
+                this.charBufferPosition += buffer.Length;
+                this.EncodeCharactersIfBufferFull();
+            }
+            else
+            {
+                int charsCopied = 0;
+                while (charsCopied < buffer.Length)
+                {
+                    int charsToCopy = Math.Min(buffer.Length - charsCopied, this.CharBufferSlack);
+                    buffer.Slice(charsCopied, charsToCopy).CopyTo(this.charBuffer.AsSpan(this.charBufferPosition));
+                    charsCopied += charsToCopy;
+                    this.charBufferPosition += charsToCopy;
+                    this.EncodeCharactersIfBufferFull();
+                }
+            }
+        }
+
+#if SPAN_BUILTIN
+        /// <inheritdoc />
+        public override void WriteLine(ReadOnlySpan<char> buffer)
+#else
+        /// <summary>
+        /// Writes a span of characters followed by a <see cref="TextWriter.NewLine"/>.
+        /// </summary>
+        /// <param name="buffer">The characters to write.</param>
+        public virtual void WriteLine(ReadOnlySpan<char> buffer)
+#endif
+        {
+            this.Write(buffer);
+            this.WriteLine();
+        }
+
+        /// <summary>
+        /// Encodes the written characters if the character buffer is full.
+        /// </summary>
+        private void EncodeCharactersIfBufferFull()
+        {
+            if (this.charBufferPosition == this.charBuffer.Length)
+            {
+                this.EncodeCharacters(flushEncoder: false);
+            }
+        }
+
+        /// <summary>
+        /// Encodes characters written so far to a buffer provided by the underyling <see cref="bufferWriter"/>.
+        /// </summary>
+        /// <param name="flushEncoder"><c>true</c> to flush the characters in the encoder; useful when finalizing the output.</param>
+        private void EncodeCharacters(bool flushEncoder)
+        {
+            if (this.charBufferPosition > 0)
+            {
+                int maxBytesLength = this.Encoding.GetMaxByteCount(this.charBufferPosition);
+                if (!this.preambleWritten)
+                {
+                    maxBytesLength += this.encodingPreamble.Length;
+                }
+
+                if (this.memory.Length - this.memoryPosition < maxBytesLength)
+                {
+                    this.CommitBytes();
+                    this.memory = this.bufferWriter.GetMemory(maxBytesLength);
+                }
+
+                if (!this.preambleWritten)
+                {
+                    this.encodingPreamble.Span.CopyTo(this.memory.Span.Slice(this.memoryPosition));
+                    this.memoryPosition += this.encodingPreamble.Length;
+                    this.preambleWritten = true;
+                }
+
+                if (MemoryMarshal.TryGetArray(this.memory, out ArraySegment<byte> segment))
+                {
+                    this.memoryPosition += this.encoder.GetBytes(this.charBuffer, 0, this.charBufferPosition, segment.Array, segment.Offset + this.memoryPosition, flush: flushEncoder);
+                }
+                else
+                {
+                    byte[] rentedByteBuffer = ArrayPool<byte>.Shared.Rent(maxBytesLength);
+                    try
+                    {
+                        int bytesWritten = this.encoder.GetBytes(this.charBuffer, 0, this.charBufferPosition, rentedByteBuffer, 0, flush: flushEncoder);
+                        rentedByteBuffer.CopyTo(this.memory.Span.Slice(this.memoryPosition));
+                        this.memoryPosition += bytesWritten;
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(rentedByteBuffer);
+                    }
+                }
+
+                this.charBufferPosition = 0;
+
+                if (this.memoryPosition == this.memory.Length)
+                {
+                    this.Flush();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Commits any written bytes to the underlying <see cref="bufferWriter"/>.
+        /// </summary>
+        private void CommitBytes()
+        {
+            if (this.memoryPosition > 0)
+            {
+                this.bufferWriter.Advance(this.memoryPosition);
+                this.memoryPosition = 0;
+                this.memory = default;
+            }
+        }
+
+        private void ThrowIfNotInitialized()
+        {
+            if (this.bufferWriter == null)
+            {
+                throw new InvalidOperationException("Call " + nameof(this.Initialize) + " first.");
+            }
+        }
+    }
+}

--- a/src/Nerdbank.Streams/SequenceTextReader.cs
+++ b/src/Nerdbank.Streams/SequenceTextReader.cs
@@ -1,0 +1,314 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+namespace Nerdbank.Streams
+{
+    using System;
+    using System.Buffers;
+    using System.IO;
+    using System.Runtime.InteropServices;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft;
+
+    /// <summary>
+    /// A <see cref="TextReader"/> that reads from a reassignable instance of <see cref="ReadOnlySequence{T}"/>.
+    /// </summary>
+    /// <remarks>
+    /// Using this is much more memory efficient than a <see cref="StreamReader"/> when reading from many different
+    /// <see cref="ReadOnlySequence{T}"/> instances because the same reader, with all its buffers, can be reused.
+    /// </remarks>
+    public class SequenceTextReader : TextReader
+    {
+        /// <summary>
+        /// A buffer of written characters that have not yet been encoded.
+        /// The <see cref="charBufferPosition"/> field tracks how many characters are represented in this buffer.
+        /// </summary>
+        private readonly char[] charBuffer = new char[512];
+
+        /// <summary>
+        /// The number of characters already read from <see cref="charBuffer"/>.
+        /// </summary>
+        private int charBufferPosition;
+
+        /// <summary>
+        /// The number of characters decoded into <see cref="charBuffer"/>.
+        /// </summary>
+        private int charBufferLength;
+
+        /// <summary>
+        /// The sequence to be decoded and read.
+        /// </summary>
+        private ReadOnlySequence<byte> sequence;
+
+        /// <summary>
+        /// The position of the next byte to decode in <see cref="sequence"/>.
+        /// </summary>
+        private SequencePosition sequencePosition;
+
+        /// <summary>
+        /// The encoding to use while decoding bytes into characters.
+        /// </summary>
+        private Encoding encoding;
+
+        /// <summary>
+        /// The decoder.
+        /// </summary>
+        private Decoder decoder;
+
+        /// <summary>
+        /// The preamble for the <see cref="encoding"/> in use.
+        /// </summary>
+        private byte[] encodingPreamble;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SequenceTextReader"/> class
+        /// without associating it with an initial <see cref="ReadOnlySequence{T}"/>.
+        /// </summary>
+        /// <remarks>
+        /// When using this constructor, call <see cref="Initialize(ReadOnlySequence{byte}, Encoding)"/>
+        /// to associate the instance with the initial byte sequence to be read.
+        /// </remarks>
+        public SequenceTextReader()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SequenceTextReader"/> class.
+        /// </summary>
+        /// <param name="sequence">The sequence to read from.</param>
+        /// <param name="encoding">The encoding to use.</param>
+        public SequenceTextReader(ReadOnlySequence<byte> sequence, Encoding encoding)
+        {
+            this.Initialize(sequence, encoding);
+        }
+
+        /// <summary>
+        /// Initializes or reinitializes this instance to read from a given <see cref="ReadOnlySequence{T}"/>.
+        /// </summary>
+        /// <param name="sequence">The sequence to read from.</param>
+        /// <param name="encoding">The encoding to use.</param>
+        public void Initialize(ReadOnlySequence<byte> sequence, Encoding encoding)
+        {
+            Requires.NotNull(encoding, nameof(encoding));
+
+            this.sequence = sequence;
+            this.sequencePosition = sequence.Start;
+
+            this.charBufferPosition = 0;
+            this.charBufferLength = 0;
+
+            if (encoding != this.encoding)
+            {
+                this.encoding = encoding ?? throw new ArgumentNullException(nameof(encoding));
+                this.decoder = this.encoding.GetDecoder();
+                this.encodingPreamble = this.encoding.GetPreamble();
+            }
+            else
+            {
+                this.decoder.Reset();
+            }
+
+            // Skip a preamble if we encounter one.
+            if (this.encodingPreamble.Length > 0 && sequence.Length >= this.encodingPreamble.Length)
+            {
+                Span<byte> provisionalRead = stackalloc byte[this.encodingPreamble.Length];
+                sequence.Slice(0, this.encodingPreamble.Length).CopyTo(provisionalRead);
+                bool match = true;
+                for (int i = 0; match && i < this.encodingPreamble.Length; i++)
+                {
+                    match = this.encodingPreamble[i] == provisionalRead[i];
+                }
+
+                if (match)
+                {
+                    // We encountered a preamble. Skip it.
+                    this.sequencePosition = this.sequence.GetPosition(this.encodingPreamble.Length, this.sequence.Start);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears references to the <see cref="ReadOnlySequence{T}"/> set by a prior call to <see cref="Initialize(ReadOnlySequence{byte}, Encoding)"/>.
+        /// </summary>
+        public void Reset()
+        {
+            this.sequence = default;
+            this.sequencePosition = default;
+        }
+
+        /// <inheritdoc />
+        public override int Peek()
+        {
+            this.DecodeCharsIfNecessary();
+            if (this.charBufferPosition == this.charBufferLength)
+            {
+                return -1;
+            }
+
+            return this.charBuffer[this.charBufferPosition];
+        }
+
+        /// <inheritdoc />
+        public override int Read()
+        {
+            int result = this.Peek();
+            if (result != -1)
+            {
+                this.charBufferPosition++;
+            }
+
+            return result;
+        }
+
+        /// <inheritdoc />
+        public override int Read(char[] buffer, int index, int count)
+        {
+            Utilities.ValidateBufferIndexAndCount(buffer, index, count);
+
+            this.DecodeCharsIfNecessary();
+
+            int copied = Math.Min(count, this.charBufferLength - this.charBufferPosition);
+            Array.Copy(this.charBuffer, this.charBufferPosition, buffer, index, copied);
+            this.charBufferPosition += copied;
+            return copied;
+        }
+
+        /// <inheritdoc />
+        public override Task<int> ReadAsync(char[] buffer, int index, int count)
+        {
+            try
+            {
+                int result = this.Read(buffer, index, count);
+                return Task.FromResult(result);
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<int>(ex);
+            }
+        }
+
+        /// <inheritdoc />
+        public override Task<int> ReadBlockAsync(char[] buffer, int index, int count)
+        {
+            try
+            {
+                int result = this.ReadBlock(buffer, index, count);
+                return Task.FromResult(result);
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<int>(ex);
+            }
+        }
+
+        /// <inheritdoc />
+        public override Task<string> ReadToEndAsync()
+        {
+            try
+            {
+                string result = this.ReadToEnd();
+                return Task.FromResult(result);
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<string>(ex);
+            }
+        }
+
+        /// <inheritdoc />
+        public override Task<string> ReadLineAsync()
+        {
+            try
+            {
+                string result = this.ReadLine();
+                return Task.FromResult(result);
+            }
+            catch (Exception ex)
+            {
+                return Task.FromException<string>(ex);
+            }
+        }
+
+#if SPAN_BUILTIN
+        /// <inheritdoc />
+        public override int Read(Span<char> buffer)
+        {
+            this.DecodeCharsIfNecessary();
+
+            int copied = Math.Min(buffer.Length, this.charBufferLength - this.charBufferPosition);
+            this.charBuffer.AsSpan(this.charBufferPosition, copied).CopyTo(buffer);
+            this.charBufferPosition += copied;
+            return copied;
+        }
+
+        /// <inheritdoc />
+        public override ValueTask<int> ReadBlockAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                int result = this.ReadBlock(buffer.Span);
+                return new ValueTask<int>(result);
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask<int>(Task.FromException<int>(ex));
+            }
+        }
+
+        /// <inheritdoc />
+        public override ValueTask<int> ReadAsync(Memory<char> buffer, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                int result = this.Read(buffer.Span);
+                return new ValueTask<int>(result);
+            }
+            catch (Exception ex)
+            {
+                return new ValueTask<int>(Task.FromException<int>(ex));
+            }
+        }
+#endif
+
+        private void DecodeCharsIfNecessary()
+        {
+            if (this.charBufferPosition == this.charBufferLength && !this.sequence.End.Equals(this.sequencePosition))
+            {
+                this.DecodeChars();
+            }
+        }
+
+        private void DecodeChars()
+        {
+            if (this.charBufferPosition == this.charBufferLength)
+            {
+                // Reset to consider our character buffer empty.
+                this.charBufferPosition = 0;
+                this.charBufferLength = 0;
+            }
+
+            while (this.charBufferLength < this.charBuffer.Length)
+            {
+                Assumes.True(this.sequence.TryGet(ref this.sequencePosition, out ReadOnlyMemory<byte> memory, advance: false));
+                if (memory.IsEmpty)
+                {
+                    this.sequencePosition = this.sequence.End;
+                    break;
+                }
+
+                if (MemoryMarshal.TryGetArray(memory, out ArraySegment<byte> segment))
+                {
+                    this.decoder.Convert(segment.Array, segment.Offset, segment.Count, this.charBuffer, this.charBufferLength, this.charBuffer.Length - this.charBufferLength, flush: false, out int bytesUsed, out int charsUsed, out bool completed);
+                    this.charBufferLength += charsUsed;
+                    this.sequencePosition = this.sequence.GetPosition(bytesUsed, this.sequencePosition);
+                }
+                else
+                {
+                    throw new NotSupportedException();
+                }
+            }
+        }
+    }
+}

--- a/src/Nerdbank.Streams/Utilities.cs
+++ b/src/Nerdbank.Streams/Utilities.cs
@@ -23,6 +23,24 @@ namespace Nerdbank.Streams
         internal static readonly Task CompletedTask = Task.FromResult(0);
 
         /// <summary>
+        /// Validates that a buffer is not null and that its index and count refer to valid positions within the buffer.
+        /// </summary>
+        /// <typeparam name="T">The type of element stored in the array.</typeparam>
+        /// <param name="buffer">The array to check.</param>
+        /// <param name="index">The starting position within the buffer.</param>
+        /// <param name="count">The number of elements to process in the buffer.</param>
+        internal static void ValidateBufferIndexAndCount<T>(T[] buffer, int index, int count)
+        {
+            Requires.NotNull(buffer, nameof(buffer));
+            Requires.Range(index >= 0, nameof(index));
+            Requires.Range(count >= 0, nameof(count));
+            if (index + count > buffer.Length)
+            {
+                throw new ArgumentException();
+            }
+        }
+
+        /// <summary>
         /// Removes an element from the middle of a queue without disrupting the other elements.
         /// </summary>
         /// <typeparam name="T">The element to remove.</typeparam>


### PR DESCRIPTION
These remove the need for AsStream() and StreamReader/StreamWriter to read and write text from ReadOnlySequence<byte> and IBufferWriter<byte> and dramatically reduce GC pressure that otherwise apply when using such adapters.

`BufferTextWriter` adapts `IBufferWriter<byte>` to be access as a `TextWriter`.
`SequenceTextReader` adapts `ReadOnlySequence<byte>` to be access as a `TextReader`.