### PR TITLE
PipeExtensions to avoid triggering the UnobservedTaskException event

### DIFF
--- a/src/Nerdbank.Streams.Tests/MockInterruptedFullDuplexStream.cs
+++ b/src/Nerdbank.Streams.Tests/MockInterruptedFullDuplexStream.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+using System;
+using System.IO;
+
+// Represents a full-duplex Stream that is in an erroneous state and throws IOException.
+internal class MockInterruptedFullDuplexStream : Stream
+{
+    public override bool CanRead => true;
+
+    public override bool CanSeek => false;
+
+    public override bool CanWrite => true;
+
+    public override long Length => throw new NotSupportedException();
+
+    public override long Position { get => throw new NotSupportedException(); set => throw new NotSupportedException(); }
+
+    public override void Flush() => throw new IOException();
+
+    public override int Read(byte[] buffer, int offset, int count) => throw new IOException();
+
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+    public override void SetLength(long value) => throw new NotSupportedException();
+
+    public override void Write(byte[] buffer, int offset, int count) => throw new IOException();
+}

--- a/src/Nerdbank.Streams.Tests/MockInterruptedWebSocket.cs
+++ b/src/Nerdbank.Streams.Tests/MockInterruptedWebSocket.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE.txt file in the project root for full license information.
+
+using System;
+using System.Net.WebSockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+// Represents a WebSocket that is in an erroneous state and throws WebSocketException.
+internal class MockInterruptedWebSocket : WebSocket
+{
+    public override WebSocketCloseStatus? CloseStatus => null;
+
+    public override string CloseStatusDescription => throw new NotImplementedException();
+
+    public override string SubProtocol => throw new NotImplementedException();
+
+    public override WebSocketState State => throw new NotImplementedException();
+
+    public override void Abort() => throw new NotImplementedException();
+
+    public override Task CloseAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string statusDescription, CancellationToken cancellationToken) => throw new NotImplementedException();
+
+    public override void Dispose()
+    {
+    }
+
+    public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> output, CancellationToken cancellationToken) =>
+        throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely);
+
+    public override Task SendAsync(ArraySegment<byte> input, WebSocketMessageType messageType, bool endOfMessage, CancellationToken cancellationToken) =>
+        throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely);
+}

--- a/src/Nerdbank.Streams/PipeExtensions.cs
+++ b/src/Nerdbank.Streams/PipeExtensions.cs
@@ -106,8 +106,9 @@ namespace Nerdbank.Streams
                     }
                     catch (Exception ex)
                     {
+                        // Propagate the exception to the reader.
                         pipe.Writer.Complete(ex);
-                        throw;
+                        return;
                     }
 
                     FlushResult result = await pipe.Writer.FlushAsync().ConfigureAwait(false);
@@ -183,8 +184,9 @@ namespace Nerdbank.Streams
                 }
                 catch (Exception ex)
                 {
+                    // Propagate the exception to the writer.
                     pipe.Reader.Complete(ex);
-                    throw;
+                    return;
                 }
             }).Forget();
             return pipe.Writer;
@@ -258,8 +260,9 @@ namespace Nerdbank.Streams
                     }
                     catch (Exception ex)
                     {
+                        // Propagate the exception to the reader.
                         pipe.Writer.Complete(ex);
-                        throw;
+                        return;
                     }
 
                     FlushResult result = await pipe.Writer.FlushAsync().ConfigureAwait(false);
@@ -315,8 +318,9 @@ namespace Nerdbank.Streams
                 }
                 catch (Exception ex)
                 {
+                    // Propagate the exception to the writer.
                     pipe.Reader.Complete(ex);
-                    throw;
+                    return;
                 }
             }).Forget();
             return pipe.Writer;


### PR DESCRIPTION
Closes #75.

I have also added tests for exception propagation in order to ensure that I did not break existing behaviors. I needed to introduce a `Stream` mock because in a normal situation `Stream.Read()` does not fail while `Stream.Write()` does (for example "connection lost").

I do not have any idea how to directly test this in unit tests, because the `UnobservedTaskException` event is global and completely avoiding the `UnobservedTaskException` event would be too restrictive for tests.