### PR TITLE
Correct the path to the .ruleset file used by library

### DIFF
--- a/src/Nerdbank.Streams/MultiplexingStream.Channel.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.Channel.cs
@@ -221,7 +221,7 @@ namespace Nerdbank.Streams
 
                 // Now wait for whatever they may have written previously to propagate to the ChannelOptions.ExistingPipe.Output writer,
                 // and then redirect all writing to that writer.
-                PipeWriter newWriter = await this.switchingToExistingPipe;
+                PipeWriter newWriter = await this.switchingToExistingPipe.ConfigureAwait(false);
                 lock (this.SyncObject)
                 {
                     this.mxStreamIOWriter = newWriter;
@@ -308,7 +308,7 @@ namespace Nerdbank.Streams
                                 this.switchingToExistingPipe = Task.Run(async delegate
                                 {
                                     // Await propagation of all bytes. Don't complete the ExistingPipe.Output when we're done because we still want to use it.
-                                    await mxStreamIncomingBytesReader.LinkToAsync(existingPipe.Output, propagateSuccessfulCompletion: false);
+                                    await mxStreamIncomingBytesReader.LinkToAsync(existingPipe.Output, propagateSuccessfulCompletion: false).ConfigureAwait(false);
                                     return existingPipe.Output;
                                 });
                             }
@@ -418,7 +418,7 @@ namespace Nerdbank.Streams
 
                 if (switchingToExistingPipe != null)
                 {
-                    currentWriter = await switchingToExistingPipe;
+                    currentWriter = await switchingToExistingPipe.ConfigureAwait(false);
                 }
 
                 if (currentWriter != initialWriter)

--- a/src/Nerdbank.Streams/Nerdbank.Streams.csproj
+++ b/src/Nerdbank.Streams/Nerdbank.Streams.csproj
@@ -3,7 +3,7 @@
     <TargetFrameworks>netstandard1.6;netstandard2.0;net46;net472;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\release.snk</AssemblyOriginatorKeyFile>
-    <CodeAnalysisRuleSet>..\Nerdbank.Streams.Tests\Nerdbank.Streams.Tests.ruleset</CodeAnalysisRuleSet>
+    <CodeAnalysisRuleSet>..\Nerdbank.Streams\Nerdbank.Streams.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <Summary>Streams for full duplex in-proc communication, wrap a WebSocket, split a stream into multiple channels, etc.</Summary>

--- a/src/Nerdbank.Streams/Nerdbank.Streams.ruleset
+++ b/src/Nerdbank.Streams/Nerdbank.Streams.ruleset
@@ -69,5 +69,7 @@
     <Rule Id="CA2242" Action="Warning" />
   </Rules>
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1130" Action="None" />
+    <Rule Id="SA1600" Action="Hidden" />
   </Rules>
 </RuleSet>


### PR DESCRIPTION
Use .ConfigureAwait(false) everywhere and rename a few Async methods.

Fixes #79