### PR TITLE
Fix Channel.Dispose to handle pending sends/receives

### DIFF
--- a/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.ruleset
+++ b/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.ruleset
@@ -74,6 +74,7 @@
     <Rule Id="SA1602" Action="Hidden" />
     <Rule Id="SA1130" Action="Hidden" />
     <Rule Id="SA1615" Action="Hidden" />
+    <Rule Id="SA1611" Action="Hidden" />
   </Rules>
   <Rules AnalyzerId="AsyncUsageAnalyzers" RuleNamespace="AsyncUsageAnalyzers">
     <Rule Id="UseConfigureAwait" Action="Error" />

--- a/src/Nerdbank.Streams.Tests/TestBase.cs
+++ b/src/Nerdbank.Streams.Tests/TestBase.cs
@@ -100,6 +100,11 @@ public abstract class TestBase : IDisposable
             }
 
             reader.AdvanceTo(readResult.Buffer.End);
+
+            if (readResult.IsCompleted && bytesReceived.Length < minLength)
+            {
+                throw new EndOfStreamException($"PipeReader completed after reading {bytesReceived.Length} of the expected {minLength} bytes.");
+            }
         }
 
         return bytesReceived.AsReadOnlySequence;

--- a/src/Nerdbank.Streams.Tests/TestBase.cs
+++ b/src/Nerdbank.Streams.Tests/TestBase.cs
@@ -31,10 +31,13 @@ public abstract class TestBase : IDisposable
 
     private readonly Random random = new Random();
 
+    private CancellationTokenRegistration timeoutLoggerRegistration;
+
     protected TestBase(ITestOutputHelper logger)
     {
         this.Logger = logger;
         this.timeoutTokenSource = new CancellationTokenSource(TestTimeout);
+        this.timeoutLoggerRegistration = this.timeoutTokenSource.Token.Register(() => logger.WriteLine("**Timeout token signaled**"));
     }
 
     public static CancellationToken ExpectedTimeoutToken => new CancellationTokenSource(ExpectedTimeout).Token;
@@ -47,6 +50,7 @@ public abstract class TestBase : IDisposable
 
     public void Dispose()
     {
+        this.timeoutLoggerRegistration.Dispose();
 #if NETFRAMEWORK
         this.processJobTracker.Dispose();
 #endif
@@ -99,6 +103,30 @@ public abstract class TestBase : IDisposable
         }
 
         return bytesReceived.AsReadOnlySequence;
+    }
+
+    public async Task DrainReaderTillCompletedAsync(PipeReader reader)
+    {
+        while (true)
+        {
+            var readResult = await reader.ReadAsync(this.TimeoutToken);
+            reader.AdvanceTo(readResult.Buffer.End);
+            if (readResult.IsCompleted)
+            {
+                break;
+            }
+        }
+    }
+
+    internal byte[] GetBuffer(int length)
+    {
+        var buffer = new byte[length];
+        for (int i = 0; i < buffer.Length; i++)
+        {
+            buffer[i] = 0xcc;
+        }
+
+        return buffer;
     }
 
     /// <summary>

--- a/src/Nerdbank.Streams.Tests/XunitTraceListener.cs
+++ b/src/Nerdbank.Streams.Tests/XunitTraceListener.cs
@@ -11,6 +11,7 @@ internal class XunitTraceListener : TraceListener
 {
     private readonly ITestOutputHelper logger;
     private readonly StringBuilder lineInProgress = new StringBuilder();
+    private readonly Stopwatch testRuntime = Stopwatch.StartNew();
     private bool disposed;
 
     internal XunitTraceListener(ITestOutputHelper logger)
@@ -112,7 +113,7 @@ internal class XunitTraceListener : TraceListener
     {
         if (!this.disposed)
         {
-            this.logger.WriteLine(this.lineInProgress.ToString() + message);
+            this.logger.WriteLine($"{this.testRuntime.Elapsed} {this.lineInProgress}{message}");
             this.lineInProgress.Clear();
         }
     }

--- a/src/Nerdbank.Streams.Tests/XunitTraceListener.cs
+++ b/src/Nerdbank.Streams.Tests/XunitTraceListener.cs
@@ -31,6 +31,15 @@ internal class XunitTraceListener : TraceListener
 #if !NETCOREAPP1_0
         if (data is ReadOnlySequence<byte> sequence)
         {
+            // Trim the traced output in case it's ridiculously huge.
+            const int maxLength = 100;
+            bool truncated = false;
+            if (sequence.Length > maxLength)
+            {
+                sequence = sequence.Slice(0, maxLength);
+                truncated = true;
+            }
+
             var sb = new StringBuilder(2 + ((int)sequence.Length * 2));
             var decoder = this.DataEncoding?.GetDecoder();
             sb.Append(decoder != null ? "\"" : "0x");
@@ -85,6 +94,11 @@ internal class XunitTraceListener : TraceListener
                 }
 
                 sb.Append('"');
+            }
+
+            if (truncated)
+            {
+                sb.Append("...");
             }
 
             this.logger.WriteLine(sb.ToString());

--- a/src/Nerdbank.Streams/MultiplexingStream.FrameHeader.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.FrameHeader.cs
@@ -4,6 +4,7 @@
 namespace Nerdbank.Streams
 {
     using System;
+    using System.Diagnostics;
     using Microsoft;
 
     /// <content>
@@ -11,6 +12,7 @@ namespace Nerdbank.Streams
     /// </content>
     public partial class MultiplexingStream
     {
+        [DebuggerDisplay("{" + nameof(DebuggerDisplay) + "}")]
         private struct FrameHeader
         {
             internal static int HeaderLength => sizeof(ControlCode) + sizeof(int) + sizeof(short);
@@ -32,6 +34,11 @@ namespace Nerdbank.Streams
             /// Must be no greater than <see cref="ushort.MaxValue"/>.
             /// </remarks>
             internal int FramePayloadLength { get; set; }
+
+            /// <summary>
+            /// Gets the text to display in the debugger when an instance of this struct is displayed.
+            /// </summary>
+            private string DebuggerDisplay => $"{this.Code} {this.ChannelId} (payload size: {this.FramePayloadLength})";
 
             internal static FrameHeader Deserialize(ReadOnlySpan<byte> buffer)
             {

--- a/src/Nerdbank.Streams/Nerdbank.Streams.ruleset
+++ b/src/Nerdbank.Streams/Nerdbank.Streams.ruleset
@@ -72,4 +72,7 @@
     <Rule Id="SA1130" Action="None" />
     <Rule Id="SA1600" Action="Hidden" />
   </Rules>
+  <Rules AnalyzerId="Microsoft.VisualStudio.Threading.Analyzers" RuleNamespace="Microsoft.VisualStudio.Threading.Analyzers">
+    <Rule Id="VSTHRD111" Action="Warning" />
+  </Rules>
 </RuleSet>


### PR DESCRIPTION
Fix Channel.Dispose to handle pending sends/receives

Frames received for a channel after its local disposal are now discarded. Any pending write+flush to the channel's PipeWriter is canceled so as to avoid plugging up the multiplexing stream when the disposed channel hasn't drained its own pipe.
When a Channel is disposed after writing and flushing bytes, a Channel that manages its own Pipe will complete transmission before actual disposal. Channels initialized with an ExistingPipe will terminate without guaranteeing that writes are completed, since we don't have any way of knowing when writes are done if the writer is not completed (which is our recommended path for disposing channels).

Fixes #88