### PR TITLE
Flush stream within semaphore

### DIFF
--- a/src/Nerdbank.Streams/MultiplexingStream.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.cs
@@ -923,7 +923,6 @@ namespace Nerdbank.Streams
             Assumes.True(payload.Length <= this.framePayloadMaxLength, nameof(payload), "Frame content exceeds max limit.");
             Verify.NotDisposed(this);
 
-            Task flushTask;
             await this.sendingSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
             try
             {
@@ -959,14 +958,12 @@ namespace Nerdbank.Streams
                 }
 
                 await writeHeaderTask.ConfigureAwait(false); // rethrow any exception
-                flushTask = this.stream.FlushIfNecessaryAsync(CancellationToken.None);
+                await this.stream.FlushIfNecessaryAsync(CancellationToken.None).ConfigureAwait(false);
             }
             finally
             {
                 this.sendingSemaphore.Release();
             }
-
-            await flushTask.ConfigureAwait(false);
         }
 
         /// <summary>


### PR DESCRIPTION
Similar fix to what we had to [fix in streamjsonrpc][1] a while ago.

[1]: https://github.com/microsoft/vs-streamjsonrpc/pull/176