### PR TITLE
Remove net472 target

### DIFF
--- a/src/Nerdbank.Streams/Nerdbank.Streams.csproj
+++ b/src/Nerdbank.Streams/Nerdbank.Streams.csproj
@@ -1,6 +1,6 @@
-﻿<Project Sdk="MSBuild.Sdk.Extras">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\release.snk</AssemblyOriginatorKeyFile>
     <CodeAnalysisRuleSet>..\Nerdbank.Streams\Nerdbank.Streams.ruleset</CodeAnalysisRuleSet>
@@ -22,9 +22,6 @@
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Strings.Designer.cs">

--- a/src/global.json
+++ b/src/global.json
@@ -1,8 +1,5 @@
 {
   "sdk": {
     "version": "2.2.300"
-  },
-  "msbuild-sdks": {
-    "MSBuild.Sdk.Extras": "1.6.61"
   }
 }


### PR DESCRIPTION
This target isn't necessary (we don't compile any differently for it compared to netstandard2.0).
I also remove the unnecessary MSBuild.Sdk.Extras and a packageref that never compiled since we removed netstandard1.6 support.