### PR TITLE
Add support for PipeReader.Complete

### DIFF
--- a/src/Nerdbank.Streams/Strings.Designer.cs
+++ b/src/Nerdbank.Streams/Strings.Designer.cs
@@ -10,7 +10,6 @@
 
 namespace Nerdbank.Streams {
     using System;
-    using System.Reflection;
     
     
     /// <summary>
@@ -40,7 +39,7 @@ namespace Nerdbank.Streams {
         internal static global::System.Resources.ResourceManager ResourceManager {
             get {
                 if (object.ReferenceEquals(resourceMan, null)) {
-                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Nerdbank.Streams.Strings", typeof(Strings).GetTypeInfo().Assembly);
+                    global::System.Resources.ResourceManager temp = new global::System.Resources.ResourceManager("Nerdbank.Streams.Strings", typeof(Strings).Assembly);
                     resourceMan = temp;
                 }
                 return resourceMan;
@@ -67,6 +66,15 @@ namespace Nerdbank.Streams {
         internal static string NotSupportedWhenExistingPipeSpecified {
             get {
                 return ResourceManager.GetString("NotSupportedWhenExistingPipeSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reading not allowed after reader is completed..
+        /// </summary>
+        internal static string ReadingAfterCompletionNotAllowed {
+            get {
+                return ResourceManager.GetString("ReadingAfterCompletionNotAllowed", resourceCulture);
             }
         }
     }

--- a/src/Nerdbank.Streams/Strings.resx
+++ b/src/Nerdbank.Streams/Strings.resx
@@ -120,4 +120,7 @@
   <data name="NotSupportedWhenExistingPipeSpecified" xml:space="preserve">
     <value>This operation is not supported when the Channel is created with ChannelOptions.ExistingPipe set.</value>
   </data>
+  <data name="ReadingAfterCompletionNotAllowed" xml:space="preserve">
+    <value>Reading not allowed after reader is completed.</value>
+  </data>
 </root>


### PR DESCRIPTION
Also no-op instead of throw for OnWriterCompleted.