### PR TITLE
Protect mxstream's underlying stream against concurrent disposal

### DIFF
--- a/src/Nerdbank.Streams/MultiplexingStream.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.cs
@@ -538,9 +538,10 @@ namespace Nerdbank.Streams
                     this.TraceSource.TraceEvent(TraceEventType.Information, (int)TraceEventId.StreamDisposed, "Disposing.");
                 }
 
-                this.stream.Dispose();
                 lock (this.syncObject)
                 {
+                    this.stream.Dispose();
+
                     foreach (var entry in this.openChannels)
                     {
                         entry.Value.Dispose();


### PR DESCRIPTION
Fixes #129