### PR TITLE
Update vs-threading dependency

### DIFF
--- a/src/Nerdbank.Streams.Interop.Tests/Nerdbank.Streams.Interop.Tests.csproj
+++ b/src/Nerdbank.Streams.Interop.Tests/Nerdbank.Streams.Interop.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.33" />
   </ItemGroup>
 
 </Project>

--- a/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
+++ b/src/Nerdbank.Streams.Tests/Nerdbank.Streams.Tests.csproj
@@ -19,7 +19,7 @@
     <Compile Include="..\Nerdbank.Streams\Utilities.cs" Link="Utilities.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.33" />
     <PackageReference Include="PInvoke.Kernel32" Version="0.5.184" />
     <PackageReference Include="StreamJsonRpc" Version="2.0.208" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -27,7 +27,7 @@
     <PackageReference Include="xunit.skippablefact" Version="1.3.12" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Moq" Version="4.12.0" />
     <PackageReference Include="System.IO.Pipes" Version="4.3.0" />
     <PackageReference Include="coverlet.msbuild" Version="2.6.3" />

--- a/src/Nerdbank.Streams/Nerdbank.Streams.csproj
+++ b/src/Nerdbank.Streams/Nerdbank.Streams.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.0.102" PrivateAssets="build;analyzers;compile" />
-    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.16" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading" Version="16.4.33" PrivateAssets="build;analyzers;compile" />
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.4.33" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="15.5.31" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.3" />


### PR DESCRIPTION
This gets us to a version that can compile with the .NET Native tool chain.