### PR TITLE
Avoid accessing ReadResult.Buffer after PipeReader.AdvanceTo

### DIFF
--- a/src/Nerdbank.Streams.Tests/MultiplexingStreamPerfTests.cs
+++ b/src/Nerdbank.Streams.Tests/MultiplexingStreamPerfTests.cs
@@ -136,14 +136,14 @@ public class MultiplexingStreamPerfTests : TestBase, IAsyncLifetime
                     {
                         await Task.WhenAll(
                             Enumerable.Range(1, ChannelCount).Select(c => Task.Run(async delegate
-                             {
-                                 byte[] serverBuffer = serverBuffers[c - 1];
-                                 var channel = await mxServer.OfferChannelAsync(string.Empty, this.TimeoutToken).WithCancellation(this.TimeoutToken);
-                                 for (int i = 0; i < segmentCount / ChannelCount; i++)
-                                 {
+                            {
+                                byte[] serverBuffer = serverBuffers[c - 1];
+                                var channel = await mxServer.OfferChannelAsync(string.Empty, this.TimeoutToken).WithCancellation(this.TimeoutToken);
+                                for (int i = 0; i < segmentCount / ChannelCount; i++)
+                                {
                                      await channel.Output.WriteAsync(serverBuffer, this.TimeoutToken);
-                                 }
-                             })));
+                                }
+                            })));
                     }),
                     Task.Run(async delegate
                     {
@@ -156,8 +156,9 @@ public class MultiplexingStreamPerfTests : TestBase, IAsyncLifetime
                                 do
                                 {
                                     var readResult = await channel.Input.ReadAsync(this.TimeoutToken);
-                                    channel.Input.AdvanceTo(readResult.Buffer.End);
                                     totalBytesRead += (int)readResult.Buffer.Length;
+                                    channel.Input.AdvanceTo(readResult.Buffer.End);
+                                    readResult.ScrubAfterAdvanceTo();
                                 }
                                 while (totalBytesRead < expectedTotalBytesRead);
                                 Assert.Equal(expectedTotalBytesRead, totalBytesRead);

--- a/src/Nerdbank.Streams/PipeExtensions.cs
+++ b/src/Nerdbank.Streams/PipeExtensions.cs
@@ -174,6 +174,7 @@ namespace Nerdbank.Streams
                         }
 
                         pipe.Reader.AdvanceTo(readResult.Buffer.End);
+                        readResult.ScrubAfterAdvanceTo();
 
                         if (readResult.IsCompleted)
                         {
@@ -343,6 +344,7 @@ namespace Nerdbank.Streams
                         }
 
                         pipe.Reader.AdvanceTo(readResult.Buffer.End);
+                        readResult.ScrubAfterAdvanceTo();
 
                         if (readResult.IsCompleted)
                         {
@@ -441,6 +443,7 @@ namespace Nerdbank.Streams
                         var result = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
                         writer.Write(result.Buffer);
                         reader.AdvanceTo(result.Buffer.End);
+                        result.ScrubAfterAdvanceTo();
                         await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
                         if (result.IsCompleted)
                         {

--- a/src/Nerdbank.Streams/PipeStream.cs
+++ b/src/Nerdbank.Streams/PipeStream.cs
@@ -290,10 +290,13 @@ namespace Nerdbank.Streams
 
             long bytesToCopyCount = Math.Min(buffer.Length, readResult.Buffer.Length);
             ReadOnlySequence<byte> slice = readResult.Buffer.Slice(0, bytesToCopyCount);
+            var isCompleted = readResult.IsCompleted && slice.End.Equals(readResult.Buffer.End);
             slice.CopyTo(buffer);
             this.reader!.AdvanceTo(slice.End);
+            readResult.ScrubAfterAdvanceTo();
+            slice = default;
 
-            if (readResult.IsCompleted && slice.End.Equals(readResult.Buffer.End))
+            if (isCompleted)
             {
                 this.reader.Complete();
                 this.readingCompleted = true;

--- a/src/Nerdbank.Streams/Utilities.cs
+++ b/src/Nerdbank.Streams/Utilities.cs
@@ -177,5 +177,14 @@ namespace Nerdbank.Streams
             buffer[0] = (byte)(value >> 8);
             buffer[1] = (byte)value;
         }
+
+        /// <summary>
+        /// Removes the memory from <see cref="ReadResult"/> that may have been recycled by a call to <see cref="PipeReader.AdvanceTo(SequencePosition)"/>.
+        /// </summary>
+        /// <param name="readResult">The <see cref="ReadResult"/> to scrub.</param>
+        /// <remarks>
+        /// The <see cref="ReadResult.IsCanceled"/> and <see cref="ReadResult.IsCompleted"/> values are preserved, but the <see cref="ReadResult.Buffer"/> is made empty by this call.
+        /// </remarks>
+        internal static void ScrubAfterAdvanceTo(this ref ReadResult readResult) => readResult = new ReadResult(default, readResult.IsCanceled, readResult.IsCompleted);
     }
 }


### PR DESCRIPTION
This fixes a bug where the last Channel transmission can be truncated.