### PR TITLE
Clear references that may be in structs from Sequence<T>

### DIFF
--- a/src/Nerdbank.Streams.Tests/SequenceTests.cs
+++ b/src/Nerdbank.Streams.Tests/SequenceTests.cs
@@ -65,6 +65,16 @@ public class SequenceTests : TestBase
         Assert.False(weakReference.IsAlive);
     }
 
+    [Fact]
+    public void ArrayPool_ReleasesReferenceInStructsOnRecycle()
+    {
+        var seq = new Sequence<ValueTuple<object>>(new MockArrayPool<ValueTuple<object>>());
+        var weakReference = StoreReferenceInSequence(seq);
+        seq.Reset();
+        GC.Collect();
+        Assert.False(weakReference.IsAlive);
+    }
+
     [Theory]
     [InlineData(0)]
     [InlineData(1)]
@@ -510,6 +520,24 @@ public class SequenceTests : TestBase
         var tracker = new WeakReference(o);
         var span = seq.GetSpan(5);
         span[0] = o;
+        seq.Advance(1);
+        return tracker;
+    }
+
+    /// <summary>
+    /// Adds a reference to an object in the sequence and returns a weak reference to it.
+    /// </summary>
+    /// <remarks>
+    /// Don't inline this because we need to guarantee the local disappears.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference StoreReferenceInSequence<T>(Sequence<ValueTuple<T>> seq)
+        where T : class, new()
+    {
+        var o = new T();
+        var tracker = new WeakReference(o);
+        var span = seq.GetSpan(5);
+        span[0] = new ValueTuple<T>(o);
         seq.Advance(1);
         return tracker;
     }

--- a/src/Nerdbank.Streams/Sequence`1.cs
+++ b/src/Nerdbank.Streams/Sequence`1.cs
@@ -308,9 +308,9 @@ namespace Nerdbank.Streams
             internal static readonly SequenceSegment Empty = new SequenceSegment();
 
             /// <summary>
-            /// A value indicating whether the element is a value type.
+            /// A value indicating whether the element may contain references (and thus must be cleared).
             /// </summary>
-            private static readonly bool IsValueTypeElement = typeof(T).GetTypeInfo().IsValueType;
+            private static readonly bool MayContainReferences = !typeof(T).GetTypeInfo().IsPrimitive;
 
 #pragma warning disable SA1011 // Closing square brackets should be spaced correctly
             /// <summary>
@@ -452,10 +452,11 @@ namespace Nerdbank.Streams
 
             private void ClearReferences(int startIndex, int length)
             {
-                // If we store references, clear them to allow the objects to be GC'd.
-                if (!IsValueTypeElement)
+                // Clear the array to allow the objects to be GC'd.
+                // Reference types need to be cleared. Value types can be structs with reference type members too, so clear everything.
+                if (MayContainReferences)
                 {
-                    this.AvailableMemory.Span.Slice(startIndex, length).Fill(default!);
+                    this.AvailableMemory.Span.Slice(startIndex, length).Clear();
                 }
             }
         }


### PR DESCRIPTION
If the `T` in `Sequence<T>` is a struct that references objects, then recycled arrays may not immediately release references to allow objects to be GC'd. This change fixes that to clear all non-primitive structs as well as reference types stored in the sequence.

Strictly speaking, *any* blittable struct needn't be cleared, but I can't find the API to test whether a struct is blittable at the moment, so I'm settling for the `Type.IsPrimitive` check.

Thanks to @bboyle1234 for pointing out the need for this change in https://github.com/AArnott/Nerdbank.Streams/commit/caee1d18457ca723f591f990783b8ffd00170987#commitcomment-38032369.