### PR TITLE
Fix reference clearing in `Sequence<T>.Reset()`

### DIFF
--- a/src/Nerdbank.Streams.Tests/SequenceTests.cs
+++ b/src/Nerdbank.Streams.Tests/SequenceTests.cs
@@ -46,6 +46,15 @@ public class SequenceTests : TestBase
     }
 
     [Fact]
+    public void Reset_AfterPartialAdvance()
+    {
+        var seq = new Sequence<object>(new MockMemoryPool<object> { Contents = { new object[4] } });
+        seq.Write(new object[3]);
+        seq.AdvanceTo(seq.AsReadOnlySequence.GetPosition(2));
+        seq.Reset();
+    }
+
+    [Fact]
     public void MemoryPool_ReleasesReferenceOnRecycle()
     {
         var seq = new Sequence<object>(new MockMemoryPool<object>());

--- a/src/Nerdbank.Streams/Sequence`1.cs
+++ b/src/Nerdbank.Streams/Sequence`1.cs
@@ -373,7 +373,7 @@ namespace Nerdbank.Streams
             /// </summary>
             internal void ResetMemory(ArrayPool<T> arrayPool)
             {
-                this.ClearReferences(this.Start, this.End);
+                this.ClearReferences(this.Start, this.End - this.Start);
                 this.Memory = default;
                 this.Next = null;
                 this.RunningIndex = 0;


### PR DESCRIPTION
Fixes #182