### PR TITLE
Add support for seeded channels to MultiplexingStream

### DIFF
--- a/src/Nerdbank.Streams.Interop.Tests/Program.cs
+++ b/src/Nerdbank.Streams.Interop.Tests/Program.cs
@@ -27,17 +27,23 @@ namespace Nerdbank.Streams.Interop.Tests
         {
             ////System.Diagnostics.Debugger.Launch();
             int protocolMajorVersion = int.Parse(args[0]);
+            var options = new MultiplexingStream.Options
+            {
+                TraceSource = { Switch = { Level = SourceLevels.Verbose } },
+                ProtocolMajorVersion = protocolMajorVersion,
+                DefaultChannelReceivingWindowSize = 64,
+                DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => new TraceSource($"Channel {id}") { Switch = { Level = SourceLevels.Verbose } },
+            };
+            if (protocolMajorVersion >= 3)
+            {
+                options.SeededChannels.Add(new MultiplexingStream.ChannelOptions());
+            }
+
             var mx = await MultiplexingStream.CreateAsync(
                 FullDuplexStream.Splice(Console.OpenStandardInput(), Console.OpenStandardOutput()),
-                new MultiplexingStream.Options
-                {
-                    TraceSource = { Switch = { Level = SourceLevels.Verbose } },
-                    ProtocolMajorVersion = protocolMajorVersion,
-                    DefaultChannelReceivingWindowSize = 64,
-                    DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => new TraceSource($"Channel {id}") { Switch = { Level = SourceLevels.Verbose } },
-                });
+                options);
             var program = new Program(mx);
-            await program.RunAsync();
+            await program.RunAsync(protocolMajorVersion);
         }
 
         private static (StreamReader Reader, StreamWriter Writer) CreateStreamIO(MultiplexingStream.Channel channel)
@@ -52,10 +58,15 @@ namespace Nerdbank.Streams.Interop.Tests
             return (reader, writer);
         }
 
-        private async Task RunAsync()
+        private async Task RunAsync(int protocolMajorVersion)
         {
             this.ClientOfferAsync().Forget();
             this.ServerOfferAsync().Forget();
+
+            if (protocolMajorVersion >= 3)
+            {
+                this.SeededChannelAsync().Forget();
+            }
 
             await this.mx.Completion;
         }
@@ -77,6 +88,14 @@ namespace Nerdbank.Streams.Interop.Tests
             string line = await r.ReadLineAsync();
             Assumes.True(line == "recv: theserver");
             r.Close();
+        }
+
+        private async Task SeededChannelAsync()
+        {
+            var channel = this.mx.AcceptChannel(0);
+            var (r, w) = CreateStreamIO(channel);
+            string line = await r.ReadLineAsync();
+            await w.WriteLineAsync($"recv: {line}");
         }
     }
 }

--- a/src/Nerdbank.Streams.Tests/MultiplexingStreamSeededChannelTests.cs
+++ b/src/Nerdbank.Streams.Tests/MultiplexingStreamSeededChannelTests.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipelines;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank.Streams;
+using Xunit;
+using Xunit.Abstractions;
+
+public class MultiplexingStreamSeededChannelTests : TestBase, IAsyncLifetime
+{
+    private Stream transport1;
+    private Stream transport2;
+    private MultiplexingStream mx1;
+    private MultiplexingStream mx2;
+    private MultiplexingStream.Options options;
+
+    public MultiplexingStreamSeededChannelTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+        this.options = new MultiplexingStream.Options
+        {
+            ProtocolMajorVersion = 3,
+            SeededChannels =
+            {
+               new MultiplexingStream.ChannelOptions { },
+               new MultiplexingStream.ChannelOptions { },
+               new MultiplexingStream.ChannelOptions { },
+            },
+        };
+
+        var mx1TraceSource = new TraceSource(nameof(this.mx1), SourceLevels.All);
+        var mx2TraceSource = new TraceSource(nameof(this.mx2), SourceLevels.All);
+
+        mx1TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+        mx2TraceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+
+        Func<string, MultiplexingStream.QualifiedChannelId, string, TraceSource> traceSourceFactory = (string mxInstanceName, MultiplexingStream.QualifiedChannelId id, string name) =>
+        {
+            var traceSource = new TraceSource(mxInstanceName + " channel " + id, SourceLevels.All);
+            traceSource.Listeners.Clear(); // remove DefaultTraceListener
+            traceSource.Listeners.Add(new XunitTraceListener(this.Logger));
+            return traceSource;
+        };
+
+        Func<MultiplexingStream.QualifiedChannelId, string, TraceSource> mx1TraceSourceFactory = (MultiplexingStream.QualifiedChannelId id, string name) => traceSourceFactory(nameof(this.mx1), id, name);
+        Func<MultiplexingStream.QualifiedChannelId, string, TraceSource> mx2TraceSourceFactory = (MultiplexingStream.QualifiedChannelId id, string name) => traceSourceFactory(nameof(this.mx2), id, name);
+
+        (this.transport1, this.transport2) = FullDuplexStream.CreatePair(new PipeOptions(pauseWriterThreshold: 2 * 1024 * 1024));
+        this.mx1 = MultiplexingStream.Create(this.transport1, new MultiplexingStream.Options(this.options) { TraceSource = mx1TraceSource, DefaultChannelTraceSourceFactoryWithQualifier = mx1TraceSourceFactory });
+        this.mx2 = MultiplexingStream.Create(this.transport2, new MultiplexingStream.Options(this.options) { TraceSource = mx2TraceSource, DefaultChannelTraceSourceFactoryWithQualifier = mx2TraceSourceFactory });
+    }
+
+    public Task InitializeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    public async Task DisposeAsync()
+    {
+        await (this.mx1?.DisposeAsync() ?? default);
+        await (this.mx2?.DisposeAsync() ?? default);
+        AssertNoFault(this.mx1);
+        AssertNoFault(this.mx2);
+
+        this.mx1?.TraceSource.Listeners.OfType<XunitTraceListener>().SingleOrDefault()?.Dispose();
+        this.mx2?.TraceSource.Listeners.OfType<XunitTraceListener>().SingleOrDefault()?.Dispose();
+    }
+
+    [Fact]
+    public async Task SeededChannels_SendContent()
+    {
+        var channel1_0 = this.mx1.AcceptChannel(0);
+        var channel1_1 = this.mx1.AcceptChannel(1);
+        var channel2_0 = this.mx2.AcceptChannel(0);
+        var channel2_1 = this.mx2.AcceptChannel(1);
+
+        await this.TransmitAndVerifyAsync(channel1_0.AsStream(), channel2_0.AsStream(), new byte[] { 1, 2, 3 });
+        await this.TransmitAndVerifyAsync(channel1_1.AsStream(), channel2_1.AsStream(), new byte[] { 4, 5, 6 });
+    }
+
+    [Fact]
+    public async Task SeededChannels_CanBeClosed()
+    {
+        var channel1 = this.mx1.AcceptChannel(0);
+        channel1.Output.Complete();
+        channel1.Input.Complete();
+
+        var channel2 = this.mx2.AcceptChannel(0);
+        var readResult = await channel2.Input.ReadAsync(this.TimeoutToken);
+        Assert.True(readResult.IsCompleted);
+        channel2.Output.Complete();
+
+        await channel1.Completion.WithCancellation(this.TimeoutToken);
+        await channel2.Completion.WithCancellation(this.TimeoutToken);
+    }
+
+    [Fact]
+    public void SeededChannels_CannotBeRejected()
+    {
+        Assert.Throws<InvalidOperationException>(() => this.mx1.RejectChannel(0));
+    }
+
+    [Fact]
+    public void SeededChannels_CannotBeAcceptedTwice()
+    {
+        this.mx1.AcceptChannel(0);
+        Assert.Throws<InvalidOperationException>(() => this.mx1.AcceptChannel(0));
+    }
+
+    [Fact]
+    public void CreateChannel_DoesNotOverlapSeededChannelIDs()
+    {
+        var channel = this.mx1.CreateChannel();
+        Assert.True(channel.QualifiedId.Id >= (ulong)this.options.SeededChannels.Count);
+    }
+
+    [Fact]
+    public void Create_VersionsWithHandshakes()
+    {
+        var pair = FullDuplexStream.CreatePair();
+        Assert.Throws<NotSupportedException>(() => MultiplexingStream.Create(pair.Item1, new MultiplexingStream.Options { ProtocolMajorVersion = 1 }));
+        Assert.Throws<NotSupportedException>(() => MultiplexingStream.Create(pair.Item1, new MultiplexingStream.Options { ProtocolMajorVersion = 2 }));
+    }
+}

--- a/src/Nerdbank.Streams/MultiplexingStream.FrameHeader.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.FrameHeader.cs
@@ -20,29 +20,26 @@ namespace Nerdbank.Streams
             /// </summary>
             internal ControlCode Code { get; set; }
 
-            /// <summary>
-            /// Gets or sets the channel that this frame refers to or carries a payload for.
-            /// </summary>
-            internal ulong? ChannelId { get; set; }
-
-            /// <summary>
-            /// Gets or sets a value indicating whether <see cref="ChannelId"/> is referring to a channel that was originally offered by the sender of this frame.
-            /// </summary>
-            /// <remarks>
-            /// This property is not used before protocol version 3.
-            /// </remarks>
-            internal bool? ChannelOfferedBySender { get; set; }
+            internal QualifiedChannelId? ChannelId { get; set; }
 
             /// <summary>
             /// Gets the ID of the channel that this frame refers to or carries a payload for.
             /// </summary>
             /// <exception cref="MultiplexingProtocolException">Thrown if <see cref="ChannelId"/> is null.</exception>
-            internal ulong RequiredChannelId => this.ChannelId ?? throw new MultiplexingProtocolException("Expected ChannelId not present in frame header.");
+            internal QualifiedChannelId RequiredChannelId => this.ChannelId ?? throw new MultiplexingProtocolException("Expected ChannelId not present in frame header.");
 
             /// <summary>
             /// Gets the text to display in the debugger when an instance of this struct is displayed.
             /// </summary>
-            private string DebuggerDisplay => $"{this.Code} {this.ChannelId}";
+            private string DebuggerDisplay => $"{this.Code} {this.ChannelId?.DebuggerDisplay}";
+
+            internal void FlipChannelPerspective()
+            {
+                if (this.ChannelId.HasValue)
+                {
+                    this.ChannelId = new QualifiedChannelId(this.ChannelId.Value.Id, (ChannelSource)(-(int)this.ChannelId.Value.Source));
+                }
+            }
         }
     }
 }

--- a/src/Nerdbank.Streams/MultiplexingStream.QualifiedChannelId.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.QualifiedChannelId.cs
@@ -12,6 +12,32 @@ namespace Nerdbank.Streams
     public partial class MultiplexingStream
     {
         /// <summary>
+        /// An enumeration of the possible sources of a channel.
+        /// </summary>
+        /// <remarks>
+        /// The ordinal values are chosen so as to make flipping the perspective as easy as negating the value,
+        /// while leaving the <see cref="Seeded"/> value unchanged.
+        /// </remarks>
+        public enum ChannelSource : sbyte
+        {
+            /// <summary>
+            /// The channel was offered by this <see cref="MultiplexingStream"/> instance to the other party.
+            /// </summary>
+            Local = 1,
+
+            /// <summary>
+            /// The channel was offered to this <see cref="MultiplexingStream"/> instance by the other party.
+            /// </summary>
+            Remote = -1,
+
+            /// <summary>
+            /// The channel was seeded during construction via the <see cref="Options.SeededChannels"/> collection.
+            /// This channel is to be <see cref="AcceptChannel(ulong, ChannelOptions?)">accepted</see> by both parties.
+            /// </summary>
+            Seeded = 0,
+        }
+
+        /// <summary>
         /// The channel ID along with which party offered it.
         /// </summary>
         [DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
@@ -21,11 +47,11 @@ namespace Nerdbank.Streams
             /// Initializes a new instance of the <see cref="QualifiedChannelId"/> struct.
             /// </summary>
             /// <param name="id">The channel id.</param>
-            /// <param name="offeredLocally">a value indicating whether <see cref="Id"/> is referring to a channel that was originally offered by the local party.</param>
-            public QualifiedChannelId(ulong id, bool offeredLocally)
+            /// <param name="source">A value indicating where the channel originated.</param>
+            public QualifiedChannelId(ulong id, ChannelSource source)
             {
                 this.Id = id;
-                this.OfferedLocally = offeredLocally;
+                this.Source = source;
             }
 
             /// <summary>
@@ -34,23 +60,23 @@ namespace Nerdbank.Streams
             public ulong Id { get; }
 
             /// <summary>
-            /// Gets a value indicating whether <see cref="Id"/> is referring to a channel that was originally offered by the local party.
+            /// Gets a value indicating where the channel originated.
             /// </summary>
-            public bool OfferedLocally { get; }
+            public ChannelSource Source { get; }
 
-            internal string DebuggerDisplay => $"{this.Id} ({(this.OfferedLocally ? "local" : "remote")})";
+            internal string DebuggerDisplay => this.ToString();
 
             /// <inheritdoc/>
-            public bool Equals(QualifiedChannelId other) => this.Id == other.Id && this.OfferedLocally == other.OfferedLocally;
+            public bool Equals(QualifiedChannelId other) => this.Id == other.Id && this.Source == other.Source;
 
             /// <inheritdoc/>
             public override bool Equals(object? obj) => obj is QualifiedChannelId other && this.Equals(other);
 
             /// <inheritdoc/>
-            public override int GetHashCode() => unchecked((int)this.Id) * (this.OfferedLocally ? 1 : -1);
+            public override int GetHashCode() => unchecked((int)this.Id) | ((int)this.Source << 29);
 
             /// <inheritdoc/>
-            public override string ToString() => $"{this.Id} ({(this.OfferedLocally ? "local" : "remote")})";
+            public override string ToString() => $"{this.Id} ({this.Source})";
         }
     }
 }

--- a/src/Nerdbank.Streams/Strings.Designer.cs
+++ b/src/Nerdbank.Streams/Strings.Designer.cs
@@ -79,6 +79,24 @@ namespace Nerdbank.Streams {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to No channel with that ID found..
+        /// </summary>
+        internal static string NoChannelFoundById {
+            get {
+                return ResourceManager.GetString("NoChannelFoundById", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This operation is not allowed on a seeded channel..
+        /// </summary>
+        internal static string NotAllowedOnSeededChannel {
+            get {
+                return ResourceManager.GetString("NotAllowedOnSeededChannel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This operation is not supported when the Channel is created with ChannelOptions.ExistingPipe set..
         /// </summary>
         internal static string NotSupportedWhenExistingPipeSpecified {
@@ -111,6 +129,15 @@ namespace Nerdbank.Streams {
         internal static string ReadingMustBeFollowedByAdvance {
             get {
                 return ResourceManager.GetString("ReadingMustBeFollowedByAdvance", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Seeded channels must be empty unless the protocol version is 3 or later..
+        /// </summary>
+        internal static string SeededChannelsRequireV3Protocol {
+            get {
+                return ResourceManager.GetString("SeededChannelsRequireV3Protocol", resourceCulture);
             }
         }
     }

--- a/src/Nerdbank.Streams/Strings.resx
+++ b/src/Nerdbank.Streams/Strings.resx
@@ -123,6 +123,12 @@
   <data name="Frozen" xml:space="preserve">
     <value>This instance has been frozen. No mutations are allowed.</value>
   </data>
+  <data name="NoChannelFoundById" xml:space="preserve">
+    <value>No channel with that ID found.</value>
+  </data>
+  <data name="NotAllowedOnSeededChannel" xml:space="preserve">
+    <value>This operation is not allowed on a seeded channel.</value>
+  </data>
   <data name="NotSupportedWhenExistingPipeSpecified" xml:space="preserve">
     <value>This operation is not supported when the Channel is created with ChannelOptions.ExistingPipe set.</value>
   </data>
@@ -134,5 +140,8 @@
   </data>
   <data name="ReadingMustBeFollowedByAdvance" xml:space="preserve">
     <value>Reading has already begun. Call AdvanceTo before reading again.</value>
+  </data>
+  <data name="SeededChannelsRequireV3Protocol" xml:space="preserve">
+    <value>Seeded channels must be empty unless the protocol version is 3 or later.</value>
   </data>
 </root>

--- a/src/Nerdbank.Streams/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Streams/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,16 +1,21 @@
 ﻿Nerdbank.Streams.MultiplexingStream.AcceptChannel(ulong id, Nerdbank.Streams.MultiplexingStream.ChannelOptions? options = null) -> Nerdbank.Streams.MultiplexingStream.Channel!
 Nerdbank.Streams.MultiplexingStream.Channel.QualifiedId.get -> Nerdbank.Streams.MultiplexingStream.QualifiedChannelId
 Nerdbank.Streams.MultiplexingStream.ChannelOfferEventArgs.QualifiedId.get -> Nerdbank.Streams.MultiplexingStream.QualifiedChannelId
+Nerdbank.Streams.MultiplexingStream.ChannelSource
+Nerdbank.Streams.MultiplexingStream.ChannelSource.Local = 1 -> Nerdbank.Streams.MultiplexingStream.ChannelSource
+Nerdbank.Streams.MultiplexingStream.ChannelSource.Remote = -1 -> Nerdbank.Streams.MultiplexingStream.ChannelSource
+Nerdbank.Streams.MultiplexingStream.ChannelSource.Seeded = 0 -> Nerdbank.Streams.MultiplexingStream.ChannelSource
 Nerdbank.Streams.MultiplexingStream.Options.DefaultChannelTraceSourceFactoryWithQualifier.get -> System.Func<Nerdbank.Streams.MultiplexingStream.QualifiedChannelId, string!, System.Diagnostics.TraceSource?>?
 Nerdbank.Streams.MultiplexingStream.Options.DefaultChannelTraceSourceFactoryWithQualifier.set -> void
 Nerdbank.Streams.MultiplexingStream.Options.GetFrozenCopy() -> Nerdbank.Streams.MultiplexingStream.Options!
 Nerdbank.Streams.MultiplexingStream.Options.IsFrozen.get -> bool
 Nerdbank.Streams.MultiplexingStream.Options.Options(Nerdbank.Streams.MultiplexingStream.Options! copyFrom) -> void
+Nerdbank.Streams.MultiplexingStream.Options.SeededChannels.get -> System.Collections.Generic.IList<Nerdbank.Streams.MultiplexingStream.ChannelOptions!>!
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Equals(Nerdbank.Streams.MultiplexingStream.QualifiedChannelId other) -> bool
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Id.get -> ulong
-Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.OfferedLocally.get -> bool
-Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId(ulong id, bool offeredLocally) -> void
+Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId(ulong id, Nerdbank.Streams.MultiplexingStream.ChannelSource source) -> void
+Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Source.get -> Nerdbank.Streams.MultiplexingStream.ChannelSource
 Nerdbank.Streams.MultiplexingStream.RejectChannel(ulong id) -> void
 override Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Equals(object? obj) -> bool
 override Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.GetHashCode() -> int

--- a/src/Nerdbank.Streams/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Streams/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,16 +1,21 @@
 ﻿Nerdbank.Streams.MultiplexingStream.AcceptChannel(ulong id, Nerdbank.Streams.MultiplexingStream.ChannelOptions? options = null) -> Nerdbank.Streams.MultiplexingStream.Channel!
 Nerdbank.Streams.MultiplexingStream.Channel.QualifiedId.get -> Nerdbank.Streams.MultiplexingStream.QualifiedChannelId
 Nerdbank.Streams.MultiplexingStream.ChannelOfferEventArgs.QualifiedId.get -> Nerdbank.Streams.MultiplexingStream.QualifiedChannelId
+Nerdbank.Streams.MultiplexingStream.ChannelSource
+Nerdbank.Streams.MultiplexingStream.ChannelSource.Local = 1 -> Nerdbank.Streams.MultiplexingStream.ChannelSource
+Nerdbank.Streams.MultiplexingStream.ChannelSource.Remote = -1 -> Nerdbank.Streams.MultiplexingStream.ChannelSource
+Nerdbank.Streams.MultiplexingStream.ChannelSource.Seeded = 0 -> Nerdbank.Streams.MultiplexingStream.ChannelSource
 Nerdbank.Streams.MultiplexingStream.Options.DefaultChannelTraceSourceFactoryWithQualifier.get -> System.Func<Nerdbank.Streams.MultiplexingStream.QualifiedChannelId, string!, System.Diagnostics.TraceSource?>?
 Nerdbank.Streams.MultiplexingStream.Options.DefaultChannelTraceSourceFactoryWithQualifier.set -> void
 Nerdbank.Streams.MultiplexingStream.Options.GetFrozenCopy() -> Nerdbank.Streams.MultiplexingStream.Options!
 Nerdbank.Streams.MultiplexingStream.Options.IsFrozen.get -> bool
 Nerdbank.Streams.MultiplexingStream.Options.Options(Nerdbank.Streams.MultiplexingStream.Options! copyFrom) -> void
+Nerdbank.Streams.MultiplexingStream.Options.SeededChannels.get -> System.Collections.Generic.IList<Nerdbank.Streams.MultiplexingStream.ChannelOptions!>!
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Equals(Nerdbank.Streams.MultiplexingStream.QualifiedChannelId other) -> bool
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Id.get -> ulong
-Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.OfferedLocally.get -> bool
-Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId(ulong id, bool offeredLocally) -> void
+Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId(ulong id, Nerdbank.Streams.MultiplexingStream.ChannelSource source) -> void
+Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Source.get -> Nerdbank.Streams.MultiplexingStream.ChannelSource
 Nerdbank.Streams.MultiplexingStream.RejectChannel(ulong id) -> void
 override Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Equals(object? obj) -> bool
 override Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.GetHashCode() -> int

--- a/src/Nerdbank.Streams/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Streams/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,16 +1,21 @@
 ﻿Nerdbank.Streams.MultiplexingStream.AcceptChannel(ulong id, Nerdbank.Streams.MultiplexingStream.ChannelOptions? options = null) -> Nerdbank.Streams.MultiplexingStream.Channel!
 Nerdbank.Streams.MultiplexingStream.Channel.QualifiedId.get -> Nerdbank.Streams.MultiplexingStream.QualifiedChannelId
 Nerdbank.Streams.MultiplexingStream.ChannelOfferEventArgs.QualifiedId.get -> Nerdbank.Streams.MultiplexingStream.QualifiedChannelId
+Nerdbank.Streams.MultiplexingStream.ChannelSource
+Nerdbank.Streams.MultiplexingStream.ChannelSource.Local = 1 -> Nerdbank.Streams.MultiplexingStream.ChannelSource
+Nerdbank.Streams.MultiplexingStream.ChannelSource.Remote = -1 -> Nerdbank.Streams.MultiplexingStream.ChannelSource
+Nerdbank.Streams.MultiplexingStream.ChannelSource.Seeded = 0 -> Nerdbank.Streams.MultiplexingStream.ChannelSource
 Nerdbank.Streams.MultiplexingStream.Options.DefaultChannelTraceSourceFactoryWithQualifier.get -> System.Func<Nerdbank.Streams.MultiplexingStream.QualifiedChannelId, string!, System.Diagnostics.TraceSource?>?
 Nerdbank.Streams.MultiplexingStream.Options.DefaultChannelTraceSourceFactoryWithQualifier.set -> void
 Nerdbank.Streams.MultiplexingStream.Options.GetFrozenCopy() -> Nerdbank.Streams.MultiplexingStream.Options!
 Nerdbank.Streams.MultiplexingStream.Options.IsFrozen.get -> bool
 Nerdbank.Streams.MultiplexingStream.Options.Options(Nerdbank.Streams.MultiplexingStream.Options! copyFrom) -> void
+Nerdbank.Streams.MultiplexingStream.Options.SeededChannels.get -> System.Collections.Generic.IList<Nerdbank.Streams.MultiplexingStream.ChannelOptions!>!
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Equals(Nerdbank.Streams.MultiplexingStream.QualifiedChannelId other) -> bool
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Id.get -> ulong
-Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.OfferedLocally.get -> bool
-Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId(ulong id, bool offeredLocally) -> void
+Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId(ulong id, Nerdbank.Streams.MultiplexingStream.ChannelSource source) -> void
+Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Source.get -> Nerdbank.Streams.MultiplexingStream.ChannelSource
 Nerdbank.Streams.MultiplexingStream.RejectChannel(ulong id) -> void
 override Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.Equals(object? obj) -> bool
 override Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.GetHashCode() -> int

--- a/src/nerdbank-streams/src/MultiplexingStreamOptions.ts
+++ b/src/nerdbank-streams/src/MultiplexingStreamOptions.ts
@@ -1,4 +1,6 @@
-export class MultiplexingStreamOptions {
+import { ChannelOptions } from "./ChannelOptions";
+
+export interface MultiplexingStreamOptions {
     /**
      * The protocol version to be used.
      * @description 1 is the original version. 2 is a protocol breaking change and adds backpressure support.
@@ -7,4 +9,13 @@ export class MultiplexingStreamOptions {
 
     /** The number of received bytes that may be buffered locally per channel (transmitted from the remote party but not yet processed). */
     defaultChannelReceivingWindowSize?: number;
+
+    /**
+     * A list of options for channels that are to be "seeded" into a new MultiplexingStream.
+     * @description Seeded channels avoid the need for a round-trip for an offer/accept packet exchange.
+     * Seeded channels are accessed within the MultiplexingStream instance by calling AcceptChannel(ulong, ChannelOptions?)
+     * with the 0-based index into this list used as the channel ID.
+     * They are only supported when ProtocolMajorVersion is at least 3.
+     */
+    seededChannels?: ChannelOptions[];
 }

--- a/src/nerdbank-streams/src/QualifiedChannelId.ts
+++ b/src/nerdbank-streams/src/QualifiedChannelId.ts
@@ -2,12 +2,37 @@ export interface QualifiedChannelId {
     /**  Gets the channel ID. */
     readonly id: number;
 
-    /** Gets a value indicating whether <see cref="Id"/> is referring to a channel that was originally offered by the local party. */
-    readonly offeredLocally: boolean;
+    /** Gets a value indicating where the channel originated. */
+    readonly source: ChannelSource;
 }
 
-export class QualifiedChannelId {
-    static toString(id: QualifiedChannelId): string {
-        return `${id.id} (${id.offeredLocally ? "local" : "remote"})`;
+/**
+ * An enumeration of the possible sources of a channel.
+ * @description The ordinal values are chosen so as to make flipping the perspective as easy as negating the value,
+ * while leaving the Seeded value unchanged.
+ */
+export enum ChannelSource {
+    /** The channel was offered by this MultiplexingStream instance to the other party. */
+    Local = 1,
+
+    /** The channel was offered to this MultiplexingStream instance by the other party. */
+    Remote = -1,
+
+    /**
+     * The channel was seeded during construction via the Options.SeededChannels collection.
+     * This channel is to be accepted by both parties.
+     */
+    Seeded = 0,
+}
+
+// tslint:disable-next-line: no-namespace
+export namespace QualifiedChannelId {
+    export function toString(id: QualifiedChannelId): string {
+        const sourceName =
+            id.source === ChannelSource.Local ? "local" :
+            id.source === ChannelSource.Remote ? "remote" :
+            id.source === ChannelSource.Seeded ? "seeded" :
+            "unknown";
+        return `${id.id} (${sourceName})`;
     }
 }

--- a/src/nerdbank-streams/src/index.ts
+++ b/src/nerdbank-streams/src/index.ts
@@ -5,3 +5,4 @@ export { IDisposableObservable } from "./IDisposableObservable";
 export { MultiplexingStream } from "./MultiplexingStream";
 export { MultiplexingStreamOptions } from "./MultiplexingStreamOptions";
 export { writeSubstream, readSubstream } from "./Utilities";
+export { QualifiedChannelId, ChannelSource } from "./QualifiedChannelId";

--- a/src/nerdbank-streams/src/tests/MultiplexingStream.SeededChannels.spec.ts
+++ b/src/nerdbank-streams/src/tests/MultiplexingStream.SeededChannels.spec.ts
@@ -1,0 +1,93 @@
+import "jasmine";
+import { Deferred } from "../Deferred";
+import { FullDuplexStream } from "../FullDuplexStream";
+import { MultiplexingStream } from "../MultiplexingStream";
+import { getBufferFrom } from "../Utilities";
+import { ChannelOptions } from "../ChannelOptions";
+
+[3].forEach(protocolMajorVersion => {
+    describe(`MultiplexingStream v${protocolMajorVersion} seeded channels`, () => {
+        let mx1: MultiplexingStream;
+        let mx2: MultiplexingStream;
+        const seededChannels: ChannelOptions[] = [{}, {}, {}]
+        beforeEach(async () => {
+            const underlyingPair = FullDuplexStream.CreatePair();
+            const mxs = await Promise.all([
+                MultiplexingStream.CreateAsync(underlyingPair.first, { protocolMajorVersion, seededChannels }),
+                MultiplexingStream.CreateAsync(underlyingPair.second, { protocolMajorVersion, seededChannels }),
+            ]);
+            mx1 = mxs.pop()!;
+            mx2 = mxs.pop()!;
+        });
+
+        afterEach(async () => {
+            if (mx1) {
+                mx1.dispose();
+                await mx1.completion;
+            }
+
+            if (mx2) {
+                mx2.dispose();
+                await mx2.completion;
+            }
+        });
+
+        it('can send content', async () => {
+            const ch1_0 = mx1.acceptChannel(0);
+            const ch1_1 = mx1.acceptChannel(1);
+            const ch2_0 = mx2.acceptChannel(0);
+            const ch2_1 = mx2.acceptChannel(1);
+
+            ch1_0.stream.write("abc");
+            expect(await getBufferFrom(ch2_0.stream, 3)).toEqual(new Buffer("abc"));
+
+            ch2_1.stream.write("abc");
+            expect(await getBufferFrom(ch1_1.stream, 3)).toEqual(new Buffer("abc"));
+        });
+
+        it('can be closed', async () => {
+            const ch1 = mx1.acceptChannel(0);
+            ch1.dispose();
+
+            const ch2 = mx2.acceptChannel(0);
+            const readBuffer = await readAsync(ch2.stream);
+            expect(readBuffer).toBeNull();
+            ch2.dispose();
+
+            await Promise.all([ch1.completion, ch2.completion]);
+        }, 120000);
+
+        it('cannot be rejected', () => {
+            expect(() => mx1.rejectChannel(0)).toThrow();
+        });
+
+        it('cannot be accepted twice', () => {
+            mx1.acceptChannel(0);
+            expect(() => mx1.acceptChannel(0)).toThrow();
+        });
+
+        it('does not overlap channel IDs', () => {
+            const channel = mx1.createChannel();
+            expect(channel.qualifiedId.id >= seededChannels.length).toBeTruthy();
+        });
+    });
+});
+
+async function readAsync(readable: NodeJS.ReadableStream): Promise<Buffer | null> {
+    let readBuffer = readable.read() as Buffer;
+
+    if (readBuffer === null) {
+        const bytesAvailable = new Deferred<void>();
+        const streamEnded = new Deferred<void>();
+        readable.once("readable", bytesAvailable.resolve.bind(bytesAvailable));
+        readable.once("end", streamEnded.resolve.bind(streamEnded));
+        await Promise.race([bytesAvailable.promise, streamEnded.promise]);
+        if (bytesAvailable.isCompleted) {
+            readBuffer = readable.read() as Buffer;
+        } else {
+            return null;
+        }
+    }
+
+    return readBuffer;
+}

--- a/src/nerdbank-streams/src/tests/MultiplexingStream.spec.ts
+++ b/src/nerdbank-streams/src/tests/MultiplexingStream.spec.ts
@@ -7,7 +7,7 @@ import { startJsonRpc } from "./jsonRpcStreams";
 import { timeout } from "./Timeout";
 import { Channel } from "../Channel";
 
-[ 1, 2, 3 ].forEach(protocolMajorVersion => {
+[1, 2, 3].forEach(protocolMajorVersion => {
     describe(`MultiplexingStream v${protocolMajorVersion}`, () => {
         let mx1: MultiplexingStream;
         let mx2: MultiplexingStream;
@@ -255,6 +255,13 @@ import { Channel } from "../Channel";
             await expectThrow(mx1.acceptChannelAsync(null!));
             await expectThrow(mx1.acceptChannelAsync(undefined!));
         });
+
+        if (protocolMajorVersion < 3) {
+            it("Rejects seeded channels", async () => {
+                const underlyingPair = FullDuplexStream.CreatePair();
+                await expectThrow<MultiplexingStream>(MultiplexingStream.CreateAsync(underlyingPair.first, { protocolMajorVersion, seededChannels: [{}] }));
+            });
+        }
     });
 
     async function expectThrow<T>(promise: Promise<T>): Promise<any> {

--- a/src/nerdbank-streams/yarn.lock
+++ b/src/nerdbank-streams/yarn.lock
@@ -24,9 +24,9 @@
     js-tokens "^4.0.0"
 
 "@types/jasmine@^3.5.10":
-  version "3.5.10"
-  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.5.10.tgz#a1a41012012b5da9d4b205ba9eba58f6cce2ab7b"
-  integrity sha512-3F8qpwBAiVc5+HPJeXJpbrl+XjawGmciN5LgiO7Gv1pl1RHtjoMNqZpqEksaPJW05ViKe8snYInRs6xB25Xdew==
+  version "3.5.11"
+  resolved "https://registry.yarnpkg.com/@types/jasmine/-/jasmine-3.5.11.tgz#ba8e80639dffbe277f49c708b45373a320d158e2"
+  integrity sha512-fg1rOd/DehQTIJTifGqGVY6q92lDgnLfs7C6t1ccSwQrMyoTGSoH6wWzhJDZb6ezhsdwAX4EIBLe8w5fXWmEng==
 
 "@types/mkdirp@^1.0.0":
   version "1.0.0"


### PR DESCRIPTION
This allows two v3 mxstream endpoints to 'hot wire' any number of channels as pre-negotiated so they can be used immediately without exchanging network packets.