### PR TITLE
Shutdown ExistingPipe streams on channel disposal

### DIFF
--- a/src/Nerdbank.Streams.Tests/MultiplexingStreamTests.cs
+++ b/src/Nerdbank.Streams.Tests/MultiplexingStreamTests.cs
@@ -208,7 +208,7 @@ public class MultiplexingStreamTests : TestBase, IAsyncLifetime
     [Fact]
     public async Task ChannelDispose_ClosesExistingStream()
     {
-        var ms = new MonitoringStream(new MemoryStream());
+        var ms = new MonitoringStream(FullDuplexStream.CreatePair().Item1);
         var disposal = new AsyncManualResetEvent();
         ms.Disposed += (s, e) => disposal.Set();
 
@@ -220,7 +220,7 @@ public class MultiplexingStreamTests : TestBase, IAsyncLifetime
     [Fact]
     public async Task RemoteChannelClose_ClosesExistingStream()
     {
-        var ms = new MonitoringStream(new MemoryStream());
+        var ms = new MonitoringStream(FullDuplexStream.CreatePair().Item1);
         var disposal = new AsyncManualResetEvent();
         ms.Disposed += (s, e) => disposal.Set();
 


### PR DESCRIPTION
When an ExistingPipe is given for a MultiplexingStream.Channel, it's very important that the Channel *complete* both the reader and the writer on that ExistingPipe so that it shuts down, releases memory, etc. When this pipe is backed by a `Stream`, it's particularly important to do this so that any held resources are released.

The PR fixes a bug where the `ExistingPipe.Input` wouldn't be completed because we were in the middle of a `ReadAsync` call on it, which would not complete because no more data was coming. We need to break out of that `ReadAsync` call so we notice the rest of the channel is shutdown and complete that reader, regardless of whether more data is coming (since the channel is gone anyway).