### PR TITLE
Avoid MultiplexingStream self-destruct when ContentProcessed follows ChannelTerminated

### DIFF
--- a/src/Nerdbank.Streams/MultiplexingStream.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.cs
@@ -1079,7 +1079,7 @@ namespace Nerdbank.Streams
                     }
                     else
                     {
-                        Assumes.False(this.channelsPendingTermination.Contains(qualifiedChannelId), "Sending a frame for channel {0}, which we've already sent termination for.", header.ChannelId);
+                        Assumes.False(this.channelsPendingTermination.Contains(qualifiedChannelId), "Sending {1} frame for channel {0}, which we've already sent termination for.", header.ChannelId, header.Code);
                     }
                 }
 


### PR DESCRIPTION
This quietly skips transmission of the `ContentProcessed` frame when it follows a `ChannelTerminated` frame.
We were already quietly ignoring incoming `ChannelProcessed` when it was for a channel that the receiving side didn't recognize as open:
https://github.com/AArnott/Nerdbank.Streams/blob/9d23cca0219f5ed800b3c34f499f9a947e11d339/src/Nerdbank.Streams/MultiplexingStream.cs#L900

And in fact there's a bigger window of opportunity here: we only detected out of order transmission of frames when we had transmitted `ChannelTerminated` but had not yet *received* `ChannelTerminated` for that same channel. After these termination frames went both ways, we forget that the channel ever existed, and if the `ContentProcessed` frame came after that, it would have been transmitted.

So clearly there's more room to improve here, but this alleviates the fatal self-destruct.

Fixes #253