### PR TITLE
Add PipeReader.AsPrebufferedStreamAsync extension method

### DIFF
--- a/src/Nerdbank.Streams.Tests/ReadOnlySequenceStreamTests.cs
+++ b/src/Nerdbank.Streams.Tests/ReadOnlySequenceStreamTests.cs
@@ -144,6 +144,11 @@ public class ReadOnlySequenceStreamTests : TestBase
             expectedArg);
         stream.Dispose();
         Assert.True(disposed);
+
+        // Verify that disposing twice does not invoke the callback twice.
+        disposed = false;
+        stream.Dispose();
+        Assert.False(disposed);
     }
 
     [Fact]

--- a/src/Nerdbank.Streams/ReadOnlySequenceStream.cs
+++ b/src/Nerdbank.Streams/ReadOnlySequenceStream.cs
@@ -206,9 +206,12 @@ namespace Nerdbank.Streams
         /// <inheritdoc/>
         protected override void Dispose(bool disposing)
         {
-            this.IsDisposed = true;
-            this.disposeAction?.Invoke(this.disposeActionArg);
-            base.Dispose(disposing);
+            if (!this.IsDisposed)
+            {
+                this.IsDisposed = true;
+                this.disposeAction?.Invoke(this.disposeActionArg);
+                base.Dispose(disposing);
+            }
         }
 
         private T ReturnOrThrowDisposed<T>(T value)

--- a/src/Nerdbank.Streams/StreamExtensions.cs
+++ b/src/Nerdbank.Streams/StreamExtensions.cs
@@ -42,7 +42,7 @@ namespace Nerdbank.Streams
         /// Exposes a <see cref="ReadOnlySequence{T}"/> of <see cref="byte"/> as a <see cref="Stream"/>.
         /// </summary>
         /// <param name="readOnlySequence">The sequence of bytes to expose as a stream.</param>
-        /// <param name="disposeAction">A delegate to invoke when the returned stream is disposed.</param>
+        /// <param name="disposeAction">A delegate to invoke when the returned stream is disposed. This might be useful to recycle the buffers backing the <paramref name="readOnlySequence"/>.</param>
         /// <param name="disposeActionArg">The argument to pass to <paramref name="disposeAction"/>.</param>
         /// <returns>The readable stream.</returns>
         public static Stream AsStream(this ReadOnlySequence<byte> readOnlySequence, Action<object?> disposeAction, object? disposeActionArg) => new ReadOnlySequenceStream(readOnlySequence, disposeAction, disposeActionArg);

--- a/src/Nerdbank.Streams/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Streams/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId() -> void
+static Nerdbank.Streams.PipeExtensions.AsPrebufferedStreamAsync(this System.IO.Pipelines.PipeReader! pipeReader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 static Nerdbank.Streams.StreamExtensions.AsStream(this System.Buffers.ReadOnlySequence<byte> readOnlySequence, System.Action<object?>! disposeAction, object? disposeActionArg) -> System.IO.Stream!

--- a/src/Nerdbank.Streams/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Streams/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId() -> void
+static Nerdbank.Streams.PipeExtensions.AsPrebufferedStreamAsync(this System.IO.Pipelines.PipeReader! pipeReader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 static Nerdbank.Streams.StreamExtensions.AsStream(this System.Buffers.ReadOnlySequence<byte> readOnlySequence, System.Action<object?>! disposeAction, object? disposeActionArg) -> System.IO.Stream!

--- a/src/Nerdbank.Streams/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Streams/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,2 +1,3 @@
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId() -> void
+static Nerdbank.Streams.PipeExtensions.AsPrebufferedStreamAsync(this System.IO.Pipelines.PipeReader! pipeReader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 static Nerdbank.Streams.StreamExtensions.AsStream(this System.Buffers.ReadOnlySequence<byte> readOnlySequence, System.Action<object?>! disposeAction, object? disposeActionArg) -> System.IO.Stream!


### PR DESCRIPTION
- PipeReaderStream.Dispose should only invoke callback once
- Add `PipeReader.AsPrebufferedStreamAsync` extension method
