### PR TITLE
Avoid 1st chance exceptions in one-way mxstream channels

### DIFF
--- a/src/Nerdbank.Streams/DuplexPipe.cs
+++ b/src/Nerdbank.Streams/DuplexPipe.cs
@@ -50,6 +50,16 @@ namespace Nerdbank.Streams
         /// <inheritdoc />
         public PipeWriter Output { get; }
 
+        /// <summary>
+        /// Checks whether the given <see cref="PipeReader"/> is known to be already completed.
+        /// </summary>
+        /// <param name="reader">The reader to check.</param>
+        /// <returns><see langword="true" /> if the <paramref name="reader"/> is known to be completed; <see langword="false"/> if the <paramref name="reader"/> is not known to be completed.</returns>
+        /// <remarks>
+        /// This method <em>may</em> return <see langword="false"/> for a completed <see cref="PipeReader"/>.
+        /// </remarks>
+        internal static bool IsDefinitelyCompleted(PipeReader reader) => reader is CompletedPipeReader;
+
         private class CompletedPipeWriter : PipeWriter
         {
             internal static readonly PipeWriter Singleton = new CompletedPipeWriter();

--- a/src/Nerdbank.Streams/PipeExtensions.cs
+++ b/src/Nerdbank.Streams/PipeExtensions.cs
@@ -430,6 +430,12 @@ namespace Nerdbank.Streams
             {
                 try
                 {
+                    if (DuplexPipe.IsDefinitelyCompleted(reader))
+                    {
+                        await writer.CompleteAsync().ConfigureAwait(false);
+                        return;
+                    }
+
                     while (true)
                     {
                         cancellationToken.ThrowIfCancellationRequested();


### PR DESCRIPTION
The added test for one-way mx channel already passed, but when run in the debugger the test reveals the 2 first chance exceptions that were thrown before the fix is applied.

Closes #252
