### PR TITLE
NestedStream: Avoid zero-length reads

### DIFF
--- a/src/Nerdbank.Streams.Tests/NestedStreamTests.cs
+++ b/src/Nerdbank.Streams.Tests/NestedStreamTests.cs
@@ -146,6 +146,16 @@ public class NestedStreamTests : TestBase
     }
 
     [Fact]
+    public async Task ReadAsync_Empty_ReturnsZero()
+    {
+        Assert.Equal(0, await this.stream.ReadAsync(Array.Empty<byte>(), 0, 0, default).WithCancellation(this.TimeoutToken));
+
+#if SPAN_BUILTIN
+        Assert.Equal(0, await this.stream.ReadAsync(Array.Empty<byte>(), default).AsTask().WithCancellation(this.TimeoutToken));
+#endif
+    }
+
+    [Fact]
     public async Task ReadAsync_NoMoreThanGiven()
     {
         byte[] buffer = new byte[this.underlyingStream.Length];
@@ -165,6 +175,12 @@ public class NestedStreamTests : TestBase
 
         Assert.Equal(0, this.stream.Read(buffer, bytesRead, buffer.Length - bytesRead));
         Assert.Equal(DefaultNestedLength, this.underlyingStream.Position);
+    }
+
+    [Fact]
+    public void Read_Empty_ReturnsZero()
+    {
+        Assert.Equal(0, this.stream.Read(Array.Empty<byte>(), 0, 0));
     }
 
     [Fact]

--- a/src/Nerdbank.Streams/NestedStream.cs
+++ b/src/Nerdbank.Streams/NestedStream.cs
@@ -74,6 +74,12 @@ namespace Nerdbank.Streams
         public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
         {
             count = (int)Math.Min(count, this.length);
+
+            if (count == 0)
+            {
+                return 0;
+            }
+
             int bytesRead = await this.underlyingStream.ReadAsync(buffer, offset, count).ConfigureAwaitRunInline();
             this.length -= bytesRead;
             return bytesRead;
@@ -83,6 +89,12 @@ namespace Nerdbank.Streams
         public override int Read(byte[] buffer, int offset, int count)
         {
             count = (int)Math.Min(count, this.length);
+
+            if (count == 0)
+            {
+                return 0;
+            }
+
             int bytesRead = this.underlyingStream.Read(buffer, offset, count);
             this.length -= bytesRead;
             return bytesRead;
@@ -93,6 +105,12 @@ namespace Nerdbank.Streams
         public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
         {
             buffer = buffer.Slice(0, (int)Math.Min(buffer.Length, this.length));
+
+            if (buffer.IsEmpty)
+            {
+                return 0;
+            }
+
             int bytesRead = await this.underlyingStream.ReadAsync(buffer, cancellationToken).ConfigureAwait(false);
             this.length -= bytesRead;
             return bytesRead;


### PR DESCRIPTION
It's possible for `NestedStream.Read` to issue a 0-length read to the underlying stream (e.g. when at the end of the stream).

Some streams behave incorrectly when you issue 0-length reads: https://github.com/dotnet/runtime/issues/52009 .

This PR prevents such calls by just returning 0 if a zero-length read would be issued.