### PR TITLE
NestedStream: CanSeek should return false when disposed

### DIFF
--- a/src/Nerdbank.Streams.Tests/NestedStreamTests.cs
+++ b/src/Nerdbank.Streams.Tests/NestedStreamTests.cs
@@ -47,7 +47,7 @@ public class NestedStreamTests : TestBase
     {
         Assert.True(this.stream.CanSeek);
         this.stream.Dispose();
-        Assert.Throws<ObjectDisposedException>(() => this.stream.CanSeek);
+        Assert.False(this.stream.CanSeek);
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class NestedStreamTests : TestBase
 
         Assert.False(stream.CanSeek);
         stream.Dispose();
-        Assert.Throws<ObjectDisposedException>(() => stream.CanSeek);
+        Assert.False(stream.CanSeek);
     }
 
     [Fact]

--- a/src/Nerdbank.Streams/NestedStream.cs
+++ b/src/Nerdbank.Streams/NestedStream.cs
@@ -55,14 +55,7 @@ namespace Nerdbank.Streams
         public override bool CanRead => !this.IsDisposed;
 
         /// <inheritdoc />
-        public override bool CanSeek
-        {
-            get
-            {
-                Verify.NotDisposed(this);
-                return this.underlyingStream.CanSeek;
-            }
-        }
+        public override bool CanSeek => !this.IsDisposed && this.underlyingStream.CanSeek;
 
         /// <inheritdoc />
         public override bool CanWrite => false;


### PR DESCRIPTION
The current implementation would throw, but the docs indicate the property should return `false`. (The other `Can*` properties on `NestedStream` correclty implement this behavior.)