### PR TITLE
Add `MultiplexingStream.Options.StartSuspended` property

### DIFF
--- a/src/Nerdbank.Streams.Tests/MultiplexingStreamOptionsTests.cs
+++ b/src/Nerdbank.Streams.Tests/MultiplexingStreamOptionsTests.cs
@@ -95,6 +95,7 @@ public class MultiplexingStreamOptionsTests
             DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => null,
             ProtocolMajorVersion = 1024,
             TraceSource = new TraceSource("test"),
+            StartSuspended = true,
             SeededChannels =
             {
                 new MultiplexingStream.ChannelOptions(),
@@ -108,6 +109,7 @@ public class MultiplexingStreamOptionsTests
         Assert.Equal(original.DefaultChannelTraceSourceFactoryWithQualifier, copy.DefaultChannelTraceSourceFactoryWithQualifier);
         Assert.Equal(original.ProtocolMajorVersion, copy.ProtocolMajorVersion);
         Assert.Equal(original.TraceSource, copy.TraceSource);
+        Assert.Equal(original.StartSuspended, copy.StartSuspended);
         Assert.NotSame(original.SeededChannels, copy.SeededChannels);
         Assert.Equal<MultiplexingStream.ChannelOptions>(original.SeededChannels, copy.SeededChannels);
     }
@@ -120,6 +122,8 @@ public class MultiplexingStreamOptionsTests
         Assert.Throws<InvalidOperationException>(() => frozen.DefaultChannelTraceSourceFactory = (id, name) => null);
         Assert.Throws<InvalidOperationException>(() => frozen.DefaultChannelTraceSourceFactoryWithQualifier = (id, name) => null);
         Assert.Throws<InvalidOperationException>(() => frozen.ProtocolMajorVersion = 5);
+        Assert.Throws<InvalidOperationException>(() => frozen.StartSuspended = true);
+        Assert.Throws<InvalidOperationException>(() => frozen.StartSuspended = false);
         Assert.Throws<InvalidOperationException>(() => frozen.TraceSource = new TraceSource("test"));
         Assert.Throws<NotSupportedException>(() => frozen.SeededChannels.Clear());
         Assert.Throws<NotSupportedException>(() => frozen.SeededChannels.Add(new MultiplexingStream.ChannelOptions()));
@@ -132,6 +136,7 @@ public class MultiplexingStreamOptionsTests
         var thawedOptions = new MultiplexingStream.Options(frozen);
         Assert.False(thawedOptions.IsFrozen);
         thawedOptions.ProtocolMajorVersion = 500;
+        thawedOptions.StartSuspended = true;
 
         Assert.False(thawedOptions.SeededChannels.IsReadOnly);
         thawedOptions.SeededChannels.Add(new MultiplexingStream.ChannelOptions());

--- a/src/Nerdbank.Streams/MultiplexingStream.Options.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.Options.cs
@@ -56,6 +56,11 @@ namespace Nerdbank.Streams
             private Func<QualifiedChannelId, string, TraceSource?>? defaultChannelTraceSourceFactoryWithQualifier;
 
             /// <summary>
+            /// Backing field for the <see cref="StartSuspended"/> property.
+            /// </summary>
+            private bool startSuspended;
+
+            /// <summary>
             /// Initializes a new instance of the <see cref="Options"/> class.
             /// </summary>
             public Options()
@@ -77,6 +82,7 @@ namespace Nerdbank.Streams
                 this.protocolMajorVersion = copyFrom.protocolMajorVersion;
                 this.defaultChannelTraceSourceFactory = copyFrom.defaultChannelTraceSourceFactory;
                 this.defaultChannelTraceSourceFactoryWithQualifier = copyFrom.defaultChannelTraceSourceFactoryWithQualifier;
+                this.startSuspended = copyFrom.startSuspended;
                 this.SeededChannels = copyFrom.SeededChannels.ToList();
             }
 
@@ -186,6 +192,26 @@ namespace Nerdbank.Streams
                 {
                     this.ThrowIfFrozen();
                     this.defaultChannelTraceSourceFactoryWithQualifier = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets a value indicating whether the <see cref="MultiplexingStream"/> should <em>not</em> start
+            /// reading from the stream immediately in order to provide time for the creator to add event handlers
+            /// such as <see cref="ChannelOffered"/>.
+            /// </summary>
+            /// <value>The default value is <see langword="false"/>.</value>
+            /// <remarks>
+            /// When set to <see langword="true" />, the owner must use <see cref="StartListening"/>
+            /// after attaching event handlers to actually being reading from the stream.
+            /// </remarks>
+            public bool StartSuspended
+            {
+                get => this.startSuspended;
+                set
+                {
+                    this.ThrowIfFrozen();
+                    this.startSuspended = value;
                 }
             }
 

--- a/src/Nerdbank.Streams/Strings.Designer.cs
+++ b/src/Nerdbank.Streams/Strings.Designer.cs
@@ -88,6 +88,24 @@ namespace Nerdbank.Streams {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This operation is only valid before listening has started..
+        /// </summary>
+        internal static string ListeningHasAlreadyStarted {
+            get {
+                return ResourceManager.GetString("ListeningHasAlreadyStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This operation is only valid after listening has started..
+        /// </summary>
+        internal static string ListeningHasNotStarted {
+            get {
+                return ResourceManager.GetString("ListeningHasNotStarted", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to No channel with that ID found..
         /// </summary>
         internal static string NoChannelFoundById {

--- a/src/Nerdbank.Streams/Strings.resx
+++ b/src/Nerdbank.Streams/Strings.resx
@@ -126,6 +126,12 @@
   <data name="InvalidSeekOrigin" xml:space="preserve">
     <value>Invalid seek origin.</value>
   </data>
+  <data name="ListeningHasAlreadyStarted" xml:space="preserve">
+    <value>This operation is only valid before listening has started.</value>
+  </data>
+  <data name="ListeningHasNotStarted" xml:space="preserve">
+    <value>This operation is only valid after listening has started.</value>
+  </data>
   <data name="NoChannelFoundById" xml:space="preserve">
     <value>No channel with that ID found.</value>
   </data>

--- a/src/Nerdbank.Streams/netcoreapp2.1/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Streams/netcoreapp2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
+Nerdbank.Streams.MultiplexingStream.Options.StartSuspended.get -> bool
+Nerdbank.Streams.MultiplexingStream.Options.StartSuspended.set -> void
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId() -> void
+Nerdbank.Streams.MultiplexingStream.StartListening() -> void
 static Nerdbank.Streams.PipeExtensions.AsPrebufferedStreamAsync(this System.IO.Pipelines.PipeReader! pipeReader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 static Nerdbank.Streams.StreamExtensions.AsStream(this System.Buffers.ReadOnlySequence<byte> readOnlySequence, System.Action<object?>? disposeAction, object? disposeActionArg) -> System.IO.Stream!

--- a/src/Nerdbank.Streams/netcoreapp3.1/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Streams/netcoreapp3.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
+Nerdbank.Streams.MultiplexingStream.Options.StartSuspended.get -> bool
+Nerdbank.Streams.MultiplexingStream.Options.StartSuspended.set -> void
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId() -> void
+Nerdbank.Streams.MultiplexingStream.StartListening() -> void
 static Nerdbank.Streams.PipeExtensions.AsPrebufferedStreamAsync(this System.IO.Pipelines.PipeReader! pipeReader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 static Nerdbank.Streams.StreamExtensions.AsStream(this System.Buffers.ReadOnlySequence<byte> readOnlySequence, System.Action<object?>? disposeAction, object? disposeActionArg) -> System.IO.Stream!

--- a/src/Nerdbank.Streams/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Nerdbank.Streams/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,6 @@
+Nerdbank.Streams.MultiplexingStream.Options.StartSuspended.get -> bool
+Nerdbank.Streams.MultiplexingStream.Options.StartSuspended.set -> void
 Nerdbank.Streams.MultiplexingStream.QualifiedChannelId.QualifiedChannelId() -> void
+Nerdbank.Streams.MultiplexingStream.StartListening() -> void
 static Nerdbank.Streams.PipeExtensions.AsPrebufferedStreamAsync(this System.IO.Pipelines.PipeReader! pipeReader, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 static Nerdbank.Streams.StreamExtensions.AsStream(this System.Buffers.ReadOnlySequence<byte> readOnlySequence, System.Action<object?>? disposeAction, object? disposeActionArg) -> System.IO.Stream!


### PR DESCRIPTION
This allows `MultiplexingStream.ChannelOffered` handlers to be added before listening has started, thereby mitigating a race condition with incoming channel offers immediately after the connection is created.

Closes #345
