### PR TITLE
Do not propagate a CancellationToken from a method arg to a long-lived state machine

### DIFF
--- a/src/Nerdbank.Streams/MultiplexingStream.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.cs
@@ -284,7 +284,9 @@ namespace Nerdbank.Streams
                 throw new NotSupportedException(Strings.SeededChannelsRequireV3Protocol);
             }
 
-            var streamWriter = stream.UsePipeWriter(cancellationToken: cancellationToken);
+            // Do NOT specify our own cancellationToken parameter in UsePipeWriter, since this PipeWriter
+            // must outlive this method and therefore should not be canceled later if that token is eventually canceled.
+            var streamWriter = stream.UsePipeWriter(cancellationToken: CancellationToken.None);
 
             var formatter = options.ProtocolMajorVersion switch
             {


### PR DESCRIPTION
This fixes #414, which is a hang that occurs when the `CancellationToken` passed to `MultiplexingStream.CreateAsync` is cancelled after `CreateAsync` has completed.