### PR TITLE
Remove unnecessary reference to System.Net.WebSockets

### DIFF
--- a/src/Nerdbank.Streams/Nerdbank.Streams.csproj
+++ b/src/Nerdbank.Streams/Nerdbank.Streams.csproj
@@ -24,7 +24,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.10.56" PrivateAssets="all" />
     <PackageReference Include="Microsoft.VisualStudio.Validation" Version="16.10.26" />
     <PackageReference Include="System.IO.Pipelines" Version="5.0.1" />
-    <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The reference brings in legacy 4.3.0 packages.