### PR TITLE
Fix hang in `MultiplexingStream.Channel.Input.CopyToAsync`

### DIFF
--- a/src/Nerdbank.Streams/MultiplexingStream.Channel.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.Channel.cs
@@ -981,10 +981,6 @@ namespace Nerdbank.Streams
 
                 public override ValueTask CompleteAsync(Exception? exception = null) => this.inner.CompleteAsync(exception);
 
-                public override Task CopyToAsync(PipeWriter destination, CancellationToken cancellationToken = default) => this.inner.CopyToAsync(destination, cancellationToken);
-
-                public override Task CopyToAsync(Stream destination, CancellationToken cancellationToken = default) => this.inner.CopyToAsync(destination, cancellationToken);
-
                 [Obsolete]
                 public override void OnWriterCompleted(Action<Exception, object> callback, object state) => this.inner.OnWriterCompleted(callback, state);
 


### PR DESCRIPTION
The overrides we had for this method simply delegated to the underlying pipe, which omitted advancing the limited backpressure 'window' as reading took place. This led to a hang when the data to be read exceeded the window size. Since the default implementation of `CopyToAsync` in the base class is simply a loop that calls `ReadAsync` and `AdvanceTo`, we can just delete our overrides. Our `AdvanceTo` method includes a window advancement.

Fixes #506