### PR TITLE
Support concurrent BeginRead and BeginWrite in CombinedStream

### DIFF
--- a/src/Nerdbank.Streams/FullDuplexStream.cs
+++ b/src/Nerdbank.Streams/FullDuplexStream.cs
@@ -143,6 +143,16 @@ namespace Nerdbank.Streams
 
             public override void WriteByte(byte value) => this.writableStream.WriteByte(value);
 
+            public override IAsyncResult BeginRead(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+                => this.readableStream.BeginRead(buffer, offset, count, callback, state);
+
+            public override IAsyncResult BeginWrite(byte[] buffer, int offset, int count, AsyncCallback callback, object state)
+                => this.writableStream.BeginWrite(buffer, offset, count, callback, state);
+
+            public override int EndRead(IAsyncResult asyncResult) => this.readableStream.EndRead(asyncResult);
+
+            public override void EndWrite(IAsyncResult asyncResult) => this.writableStream.EndWrite(asyncResult);
+
 #if SPAN_BUILTIN
 
             public override void Write(ReadOnlySpan<byte> buffer) => this.writableStream.Write(buffer);

--- a/test/Nerdbank.Streams.Tests/FullDuplexStreamPairTests.cs
+++ b/test/Nerdbank.Streams.Tests/FullDuplexStreamPairTests.cs
@@ -95,14 +95,35 @@ public class FullDuplexStreamPairTests : TestBase
     public async Task Read_ConcurrentWrite()
     {
         byte[] readBuffer = new byte[5];
-        IAsyncResult beginRead = this.stream1.BeginRead(readBuffer, 0, readBuffer.Length, null, null);
-        IAsyncResult beginWrite = this.stream1.BeginWrite(this.GetBuffer(1), 0, 1, null, null);
+        var readStarted = new TaskCompletionSource<bool>();
+        Task<int> readTask = Task.Factory.FromAsync(
+            (cb, state) =>
+            {
+                IAsyncResult asyncResult = this.stream1.BeginRead(readBuffer, 0, readBuffer.Length, cb, state);
+                readStarted.SetResult(true);
+                return asyncResult;
+            },
+            ar => this.stream1.EndRead(ar),
+            null);
 
+        await readStarted.Task;
+        var writeStarted = new TaskCompletionSource<bool>();
+        Task writeTask = Task.Factory.FromAsync(
+            (cb, state) =>
+            {
+                IAsyncResult asyncResult = this.stream1.BeginWrite(this.GetBuffer(1), 0, 1, cb, state);
+                writeStarted.SetResult(true);
+                return asyncResult;
+            },
+            ar => this.stream1.EndWrite(ar),
+            null);
+
+        await writeStarted.Task;
         await this.stream2.WriteAsync(Data5Bytes, 0, Data5Bytes.Length);
 
-        this.stream1.EndWrite(beginWrite);
-        int bytesRead = this.stream1.EndRead(beginRead);
+        int bytesRead = await readTask;
         this.stream2.ReadByte();
+        await writeTask;
 
         Assert.Equal(Data5Bytes.Length, bytesRead);
         Assert.Equal(Data5Bytes, readBuffer);

--- a/test/Nerdbank.Streams.Tests/FullDuplexStreamPairTests.cs
+++ b/test/Nerdbank.Streams.Tests/FullDuplexStreamPairTests.cs
@@ -92,6 +92,23 @@ public class FullDuplexStreamPairTests : TestBase
     }
 
     [Fact]
+    public async Task Read_ConcurrentWrite()
+    {
+        byte[] readBuffer = new byte[5];
+        IAsyncResult beginRead = this.stream1.BeginRead(readBuffer, 0, readBuffer.Length, null, null);
+        IAsyncResult beginWrite = this.stream1.BeginWrite(this.GetBuffer(1), 0, 1, null, null);
+
+        await this.stream2.WriteAsync(Data5Bytes, 0, Data5Bytes.Length);
+
+        this.stream1.EndWrite(beginWrite);
+        int bytesRead = this.stream1.EndRead(beginRead);
+        this.stream2.ReadByte();
+
+        Assert.Equal(Data5Bytes.Length, bytesRead);
+        Assert.Equal(Data5Bytes, readBuffer);
+    }
+
+    [Fact]
     public async Task Read_ReturnsNoBytesWhenRemoteStreamClosed()
     {
         // Verify that closing the transmitting stream after reading has been requested


### PR DESCRIPTION
The base implementation of Stream does not allow concurrent BeginRead and BeginWrite operations.

A NetworkStream overrides these methods to fully support asynchronous operations.

Therefore I simply forward the calls to the underlying readable and writable streams to achieve the same behavior.

This will fix https://github.com/microsoft/vs-streamjsonrpc/issues/822