### PR TITLE
Do not allocate from pool when MinimumSpanLength is defined...

### DIFF
--- a/src/Nerdbank.Streams.Tests/MockMemoryPool`1.cs
+++ b/src/Nerdbank.Streams.Tests/MockMemoryPool`1.cs
@@ -12,6 +12,7 @@ internal class MockMemoryPool<T> : MemoryPool<T>
     public override int MaxBufferSize => throw new NotImplementedException();
 
     public int RentCallCount { get; private set; }
+
     public List<Memory<T>> Contents { get; } = new List<Memory<T>>();
 
     /// <summary>

--- a/src/Nerdbank.Streams.Tests/MockMemoryPool`1.cs
+++ b/src/Nerdbank.Streams.Tests/MockMemoryPool`1.cs
@@ -11,6 +11,7 @@ internal class MockMemoryPool<T> : MemoryPool<T>
 {
     public override int MaxBufferSize => throw new NotImplementedException();
 
+    public int RentCallCount { get; private set; }
     public List<Memory<T>> Contents { get; } = new List<Memory<T>>();
 
     /// <summary>
@@ -23,6 +24,8 @@ internal class MockMemoryPool<T> : MemoryPool<T>
 
     public override IMemoryOwner<T> Rent(int minBufferSize = -1)
     {
+        this.RentCallCount++;
+
         Memory<T> result;
         if (minBufferSize <= 0)
         {

--- a/src/Nerdbank.Streams.Tests/SequenceTests.cs
+++ b/src/Nerdbank.Streams.Tests/SequenceTests.cs
@@ -440,6 +440,24 @@ public class SequenceTests : TestBase
     }
 
     [Fact]
+    public void MinimumSpanLength_DoesNotAllocateIfThereAreBytesLeft()
+    {
+        var pool = new MockMemoryPool<byte>();
+        var seq = new Sequence<byte>(pool)
+        {
+            MinimumSpanLength = 64,
+        };
+        Span<byte> firstSpan = seq.GetSpan(1);
+        seq.Advance(1);
+        Span<byte> secondSpan = seq.GetSpan(63);
+        seq.Advance(63);
+
+        Assert.Equal(64, firstSpan.Length);
+        Assert.Equal(63, secondSpan.Length);
+        Assert.Equal(1, pool.RentCallCount);
+    }
+
+    [Fact]
     public void MinimumSpanLength_ZeroGetsPoolRecommendation()
     {
         var pool = new MockMemoryPool<int>();

--- a/src/Nerdbank.Streams/Sequence`1.cs
+++ b/src/Nerdbank.Streams/Sequence`1.cs
@@ -265,10 +265,9 @@ namespace Nerdbank.Streams
             }
             else
             {
-                sizeHint = Math.Max(this.MinimumSpanLength, sizeHint);
                 if (this.last == null || this.last.WritableBytes < sizeHint)
                 {
-                    minBufferSize = sizeHint;
+                    minBufferSize = Math.Max(this.MinimumSpanLength, sizeHint);
                 }
             }
 


### PR DESCRIPTION
and there is space left in the current allocation. This is a fix for #532.