### PR TITLE
Removed unstable tag from version 2.9-alpha

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "2.9-alpha",
+  "version": "2.9",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:.\\d+)?$",


### PR DESCRIPTION
Removes the `alpha` tag from Nerbank.Streams version for version stabilization with the release of 17.4 Preview 3