### PR TITLE
Fix of the ReadOnlySequenceStream Seek method

### DIFF
--- a/src/Nerdbank.Streams/ReadOnlySequenceStream.cs
+++ b/src/Nerdbank.Streams/ReadOnlySequenceStream.cs
@@ -143,7 +143,7 @@ namespace Nerdbank.Streams
                     else
                     {
                         relativeTo = this.readOnlySequence.Start;
-                        offset += this.Position;
+                        offset += this.Length;
                     }
 
                     break;

--- a/test/Nerdbank.Streams.Tests/ReadOnlySequenceStreamTests.cs
+++ b/test/Nerdbank.Streams.Tests/ReadOnlySequenceStreamTests.cs
@@ -239,10 +239,12 @@ public class ReadOnlySequenceStreamTests : TestBase
         Assert.Equal(5, stream.Position);
         Assert.Equal(stream.Position + 1, stream.ReadByte());
 
+        stream.Position = 0;
         Assert.Equal(9, stream.Seek(0, SeekOrigin.End));
         Assert.Equal(9, stream.Position);
         Assert.Equal(-1, stream.ReadByte());
 
+        stream.Position = 0;
         Assert.Equal(8, stream.Seek(-1, SeekOrigin.End));
         Assert.Equal(8, stream.Position);
         Assert.Equal(stream.Position + 1, stream.ReadByte());


### PR DESCRIPTION
The ReadOnlySequenceStream Seek method does not function correctly with SeekOrigin.End and a negative offset. It seeks relative to the current position instead of the end of the stream.

This pull request fixes this issue and updates the unit test. The test did not catch the error because the stream was positioned at the end when testing this method.