### PR TITLE
Fix CPU spin in the JavaScript implementation side

### DIFF
--- a/azure-pipelines/node.yml
+++ b/azure-pipelines/node.yml
@@ -30,4 +30,4 @@ steps:
   displayName: 🧪 yarn tslint
   inputs:
     projectDirectory: src/nerdbank-streams
-    arguments: tslint --project .
+    arguments: lint

--- a/src/nerdbank-streams/package.json
+++ b/src/nerdbank-streams/package.json
@@ -52,6 +52,7 @@
     "await-semaphore": "^0.1.3",
     "cancellationtoken": "^2.0.1",
     "caught": "^0.1.3",
-    "msgpack-lite": "^0.1.26"
+    "msgpack-lite": "^0.1.26",
+    "plexer": "^2.0.0"
   }
 }

--- a/src/nerdbank-streams/package.json
+++ b/src/nerdbank-streams/package.json
@@ -28,7 +28,8 @@
   "scripts": {
     "build": "tsc -p gulpfile.tsconfig.json && gulp",
     "watch": "node ./node_modules/typescript/bin/tsc -p tsconfig.json -w",
-    "test": "jasmine"
+    "test": "jasmine",
+    "lint": "tslint --project ."
   },
   "devDependencies": {
     "@types/jasmine": "^4.0.3",

--- a/src/nerdbank-streams/src/FullDuplexStream.ts
+++ b/src/nerdbank-streams/src/FullDuplexStream.ts
@@ -1,4 +1,5 @@
 import { Duplex, PassThrough } from "stream";
+import duplexer = require('plexer')
 
 export class FullDuplexStream {
     public static CreatePair(): { first: Duplex, second: Duplex } {
@@ -11,20 +12,6 @@ export class FullDuplexStream {
     }
 
     public static Splice(readable: NodeJS.ReadableStream, writable: NodeJS.WritableStream): Duplex {
-        const duplex = new Duplex({
-            write(chunk, encoding, callback) {
-                writable.write(chunk, encoding, callback);
-            },
-
-            final(callback) {
-                writable.end(callback);
-            },
-        });
-
-        // All reads and events come directly from the readable stream.
-        duplex.read = readable.read.bind(readable);
-        duplex.on = readable.on.bind(readable) as any;
-
-        return duplex;
+        return duplexer(writable, readable)
     }
 }

--- a/src/nerdbank-streams/src/Utilities.ts
+++ b/src/nerdbank-streams/src/Utilities.ts
@@ -45,7 +45,7 @@ export function readAsync(stream: NodeJS.ReadableStream, cancellationToken?: Can
         throw new Error('Stream must not be in flowing mode.');
     }
 
-    let result = stream.read()
+    const result = stream.read()
     if (result) {
         return Promise.resolve(result)
     }

--- a/src/nerdbank-streams/src/Utilities.ts
+++ b/src/nerdbank-streams/src/Utilities.ts
@@ -35,20 +35,114 @@ export function writeSubstream(stream: NodeJS.WritableStream): NodeJS.WritableSt
     });
 }
 
-export function readSubstream(stream: NodeJS.ReadableStream): NodeJS.ReadableStream {
+/**
+ * Reads the next chunk from a stream, asynchronously waiting for more to be read if necessary.
+ * @param stream The stream to read from.
+ * @param cancellationToken A token whose cancellation will result in immediate rejection of the previously returned promise.
+ * @returns The result of reading from the stream. This will be null if the end of the stream is reached before any more can be read.
+ */
+export function readAsync(stream: NodeJS.ReadableStream, cancellationToken?: CancellationToken): Promise<string | Buffer | null> {
+    let result = stream.read()
+    if (result) {
+        return Promise.resolve(result)
+    }
+
+    return new Promise<string | Buffer | null>((resolve, reject) => {
+        const ctReg = cancellationToken?.onCancelled(reason => {
+            cleanup();
+            reject(reason);
+        });
+        stream.once('data', onData);
+        stream.once('error', onError);
+        stream.once('end', onEnd);
+
+        function onData(chunk) {
+            cleanup();
+            resolve(chunk);
+        }
+
+        function onError(...args) {
+            cleanup();
+            reject(...args);
+        }
+
+        function onEnd() {
+            cleanup();
+            resolve(null);
+        }
+
+        function cleanup() {
+            stream.off('data', onData);
+            stream.off('error', onError);
+            stream.off('end', onEnd);
+            if (ctReg) {
+                ctReg();
+            }
+        }
+    })
+}
+
+/**
+ * Returns a readable stream that will read just a slice of some existing stream.
+ * @param stream The stream to read from.
+ * @param length The maximum number of bytes to read from the stream.
+ * @returns A stream that will read up to the given number of elements, leaving the rest in the underlying stream.
+ */
+export function sliceStream(stream: NodeJS.ReadableStream, length: number): Readable {
     return new Readable({
         async read(_: number) {
-            const lenBuffer = await getBufferFrom(stream, 4);
-            const dv = new DataView(lenBuffer.buffer, lenBuffer.byteOffset, lenBuffer.length);
-            const chunkSize = dv.getUint32(0, false);
-            if (chunkSize === 0) {
-                this.push(null);
-                return;
+            while (length > 0) {
+                const chunk = await readAsync(stream);
+                if (!chunk) {
+                    // We've reached the end of the source stream.
+                    this.push(null);
+                    return;
+                }
+
+                const countToConsume = Math.min(length, chunk.length)
+                length -= countToConsume
+                stream.unshift(chunk.slice(countToConsume))
+                if (!this.push(chunk.slice(0, countToConsume))) {
+                    return;
+                }
             }
 
-            // TODO: make this *stream* instead of read as an atomic chunk.
-            const payload = await getBufferFrom(stream, chunkSize);
-            this.push(payload);
+            this.push(null);
+        },
+    });
+}
+
+export function readSubstream(stream: NodeJS.ReadableStream): NodeJS.ReadableStream {
+    let currentSlice: Readable | null = null
+    return new Readable({
+        async read(_: number) {
+            while (true) {
+                if (currentSlice === null) {
+                    const lenBuffer = await getBufferFrom(stream, 4);
+                    const dv = new DataView(lenBuffer.buffer, lenBuffer.byteOffset, lenBuffer.length);
+                    const length = dv.getUint32(0, false);
+                    if (length === 0) {
+                        // We've reached the end of the substream.
+                        this.push(null);
+                        return;
+                    }
+
+                    currentSlice = sliceStream(stream, length)
+                }
+
+                while (currentSlice !== null) {
+                    const chunk = await readAsync(currentSlice);
+                    if (!chunk) {
+                        // We've reached the end of this chunk. We'll have to read the next header.
+                        currentSlice = null;
+                        break;
+                    }
+
+                    if (!this.push(chunk)) {
+                        return;
+                    }
+                }
+            }
         },
     });
 }

--- a/src/nerdbank-streams/src/index.ts
+++ b/src/nerdbank-streams/src/index.ts
@@ -4,5 +4,5 @@ export { FullDuplexStream } from "./FullDuplexStream";
 export { IDisposableObservable } from "./IDisposableObservable";
 export { MultiplexingStream } from "./MultiplexingStream";
 export { MultiplexingStreamOptions } from "./MultiplexingStreamOptions";
-export { writeSubstream, readSubstream } from "./Utilities";
+export { writeSubstream, readSubstream, readAsync, sliceStream } from "./Utilities";
 export { QualifiedChannelId, ChannelSource } from "./QualifiedChannelId";

--- a/src/nerdbank-streams/src/tests/FullDuplexStream.spec.ts
+++ b/src/nerdbank-streams/src/tests/FullDuplexStream.spec.ts
@@ -1,7 +1,7 @@
 import { PassThrough, Readable, Writable } from "stream";
 import { Deferred } from "../Deferred";
 import { FullDuplexStream } from "../FullDuplexStream";
-import { getBufferFrom } from "../Utilities";
+import { getBufferFrom, readAsync } from "../Utilities";
 import { delay } from "./Timeout";
 
 describe("FullDuplexStream.CreatePair", () => {
@@ -24,20 +24,20 @@ describe("FullDuplexStream.CreatePair", () => {
         await endPropagatesEndEvent(pair.second, pair.first);
     });
 
-    it("stream1 write end leads to stream2 finish event", async () => {
+    it("stream1 write end leads to stream1 finish event", async () => {
         const pair = FullDuplexStream.CreatePair();
-        await endPropagatesFinishEvent(pair.first, pair.second);
-        await endPropagatesFinishEvent(pair.second, pair.first);
+        await endRaisesFinishEvent(pair.first);
+        await endRaisesFinishEvent(pair.second);
     });
 
     async function writePropagation(first: Writable, second: Readable): Promise<void> {
         first.write("abc");
-        expect(second.read()).toEqual(Buffer.from("abc"));
+        expect(await readAsync(second)).toEqual(Buffer.from("abc"));
     }
 
-    async function endPropagatesFinishEvent(first: Writable, second: Readable): Promise<void> {
+    async function endRaisesFinishEvent(first: Writable): Promise<void> {
         const signal = new Deferred<void>();
-        second.once("finish", () => {
+        first.once("finish", () => {
             signal.resolve();
         });
         expect(signal.isCompleted).toBe(false);
@@ -63,8 +63,8 @@ describe("FullDuplexStream.Splice", () => {
     let duplex: NodeJS.ReadWriteStream;
 
     beforeEach(() => {
-        readable = new PassThrough({ writableHighWaterMark : 8 });
-        writable = new PassThrough({ writableHighWaterMark : 8 });
+        readable = new PassThrough({ writableHighWaterMark: 8 });
+        writable = new PassThrough({ writableHighWaterMark: 8 });
         duplex = FullDuplexStream.Splice(readable, writable);
     });
 
@@ -87,6 +87,12 @@ describe("FullDuplexStream.Splice", () => {
         buffer = await getBufferFrom(writable, 1, true);
         expect(buffer).toBeNull();
     });
+
+    it("unshift", async function () {
+        duplex.unshift(Buffer.from([1, 2, 3]))
+        const result = duplex.read()
+        expect(result).toEqual(Buffer.from([1, 2, 3]))
+    })
 
     it("Read should yield when data is not ready", async () => {
         const task = writeToStream(duplex, "abcdefgh", 4);

--- a/src/nerdbank-streams/src/tests/FullDuplexStream.spec.ts
+++ b/src/nerdbank-streams/src/tests/FullDuplexStream.spec.ts
@@ -88,7 +88,7 @@ describe("FullDuplexStream.Splice", () => {
         expect(buffer).toBeNull();
     });
 
-    it("unshift", async function () {
+    it("unshift", async () => {
         duplex.unshift(Buffer.from([1, 2, 3]))
         const result = duplex.read()
         expect(result).toEqual(Buffer.from([1, 2, 3]))

--- a/src/nerdbank-streams/src/tests/MultiplexingStream.Interop.spec.ts
+++ b/src/nerdbank-streams/src/tests/MultiplexingStream.Interop.spec.ts
@@ -107,9 +107,13 @@ import { ChannelOptions } from "../ChannelOptions";
             if (readBuffer === null) {
                 const bytesAvailable = new Deferred<void>();
                 const streamEnded = new Deferred<void>();
-                readable.once("readable", bytesAvailable.resolve.bind(bytesAvailable));
-                readable.once("end", streamEnded.resolve.bind(streamEnded));
+                const bytesAvailableCallback = bytesAvailable.resolve.bind(bytesAvailable);
+                const streamEndedCallback = streamEnded.resolve.bind(streamEnded);
+                readable.once("readable", bytesAvailableCallback);
+                readable.once("end", streamEndedCallback);
                 await Promise.race([bytesAvailable.promise, streamEnded.promise]);
+                readable.removeListener("readable", bytesAvailableCallback);
+                readable.removeListener("end", streamEndedCallback);
                 if (bytesAvailable.isCompleted) {
                     readBuffer = readable.read() as Buffer;
                 } else {

--- a/src/nerdbank-streams/src/tests/MultiplexingStream.SeededChannels.spec.ts
+++ b/src/nerdbank-streams/src/tests/MultiplexingStream.SeededChannels.spec.ts
@@ -79,9 +79,13 @@ async function readAsync(readable: NodeJS.ReadableStream): Promise<Buffer | null
     if (readBuffer === null) {
         const bytesAvailable = new Deferred<void>();
         const streamEnded = new Deferred<void>();
-        readable.once("readable", bytesAvailable.resolve.bind(bytesAvailable));
-        readable.once("end", streamEnded.resolve.bind(streamEnded));
+        const bytesAvailableCallback = bytesAvailable.resolve.bind(bytesAvailable);
+        const streamEndedCallback = streamEnded.resolve.bind(streamEnded);
+        readable.once("readable", bytesAvailableCallback);
+        readable.once("end", streamEndedCallback);
         await Promise.race([bytesAvailable.promise, streamEnded.promise]);
+        readable.removeListener("readable", bytesAvailableCallback);
+        readable.removeListener("end", streamEndedCallback);
         if (bytesAvailable.isCompleted) {
             readBuffer = readable.read() as Buffer;
         } else {

--- a/src/nerdbank-streams/src/tests/Substream.spec.ts
+++ b/src/nerdbank-streams/src/tests/Substream.spec.ts
@@ -134,12 +134,8 @@ describe("Substream", () => {
             await endAsync(thru);
 
             const substream = readSubstream(thru);
-            let readPayload = await getBufferFrom(substream, payload1.length);
-            expect(readPayload).toEqual(payload1);
-            readPayload = await getBufferFrom(substream, payload2.length);
-            expect(readPayload).toEqual(payload2);
-
-            await expectEndOfStream(substream);
+            let readPayload = await getBufferFrom(substream, 10, true);
+            expect(readPayload).toEqual(Buffer.from([1, 2, 3, 4, 5, 6]));
             await expectEndOfStream(thru);
         });
 
@@ -187,6 +183,8 @@ describe("Substream", () => {
     }
 
     function expectEndOfStream(stream: NodeJS.ReadableStream): Promise<void> {
+        expect(stream.read()).toBeNull()
+        stream.resume();
         return new Promise<void>((resolve, reject) => {
             stream.once("end", () => resolve());
             stream.once("data", () => reject(new Error('EOF expected.')));

--- a/src/nerdbank-streams/src/tests/Substream.spec.ts
+++ b/src/nerdbank-streams/src/tests/Substream.spec.ts
@@ -134,7 +134,7 @@ describe("Substream", () => {
             await endAsync(thru);
 
             const substream = readSubstream(thru);
-            let readPayload = await getBufferFrom(substream, 10, true);
+            const readPayload = await getBufferFrom(substream, 10, true);
             expect(readPayload).toEqual(Buffer.from([1, 2, 3, 4, 5, 6]));
             await expectEndOfStream(thru);
         });

--- a/src/nerdbank-streams/src/tests/Utilities.spec.ts
+++ b/src/nerdbank-streams/src/tests/Utilities.spec.ts
@@ -7,8 +7,8 @@ beforeEach(() => {
     thru = new PassThrough();
 })
 
-describe('readAsync', function () {
-    it('returns immediately with results', async function () {
+describe('readAsync', () => {
+    it('returns immediately with results', async () => {
         thru.write(Buffer.from([1, 2, 3]))
         thru.write(Buffer.from([4, 5, 6]))
 
@@ -16,7 +16,7 @@ describe('readAsync', function () {
         expect(result).toEqual(Buffer.from([1, 2, 3, 4, 5, 6]))
     })
 
-    it('to wait for data', async function () {
+    it('to wait for data', async () => {
         const resultPromise = readAsync(thru);
 
         thru.write(Buffer.from([1, 2, 3]))
@@ -26,18 +26,18 @@ describe('readAsync', function () {
         expect(result).toEqual(Buffer.from([1, 2, 3]))
     })
 
-    it('to return null at EOF', async function () {
+    it('to return null at EOF', async () => {
         thru.end()
         expect(await readAsync(thru)).toBeNull()
     })
 
-    it('to propagate errors', async function () {
+    it('to propagate errors', async () => {
         const error = new Error('Mock error')
         thru.destroy(error)
         await expectAsync(readAsync(thru)).toBeRejectedWith(error);
     })
 
-    it('bails on cancellation', async function () {
+    it('bails on cancellation', async () => {
         const cts = CancellationToken.create();
         const readPromise = readAsync(thru, cts.token);
         cts.cancel();
@@ -45,14 +45,14 @@ describe('readAsync', function () {
     })
 })
 
-describe('sliceStream', function () {
-    it('returns null on empty', async function () {
+describe('sliceStream', () => {
+    it('returns null on empty', async () => {
         thru.end()
         const slice = sliceStream(thru, 5)
         expect(slice.read()).toBeNull()
     })
 
-    it('returns subset of upper stream', async function () {
+    it('returns subset of upper stream', async () => {
         thru.push(Buffer.from([1, 2, 3, 4, 5, 6]))
         const slice = sliceStream(thru, 3)
         expect(await readAsync(slice)).toEqual(Buffer.from([1, 2, 3]))
@@ -60,7 +60,7 @@ describe('sliceStream', function () {
         expect(await readAsync(thru)).toEqual(Buffer.from([4, 5, 6]))
     })
 
-    it('handles slice that exceeds stream length', async function () {
+    it('handles slice that exceeds stream length', async () => {
         thru.end(Buffer.from([1, 2, 3]))
         const slice = sliceStream(thru, 6)
 

--- a/src/nerdbank-streams/src/tests/Utilities.spec.ts
+++ b/src/nerdbank-streams/src/tests/Utilities.spec.ts
@@ -59,4 +59,13 @@ describe('sliceStream', function () {
         expect(await readAsync(slice)).toBeNull()
         expect(await readAsync(thru)).toEqual(Buffer.from([4, 5, 6]))
     })
+
+    it('handles slice that exceeds stream length', async function () {
+        thru.end(Buffer.from([1, 2, 3]))
+        const slice = sliceStream(thru, 6)
+
+        const result = await readAsync(slice)
+        expect(result).toEqual(Buffer.from([1, 2, 3]))
+        expect(await readAsync(slice)).toBeNull()
+    })
 })

--- a/src/nerdbank-streams/src/tests/Utilities.spec.ts
+++ b/src/nerdbank-streams/src/tests/Utilities.spec.ts
@@ -1,0 +1,62 @@
+import CancellationToken from "cancellationtoken";
+import { PassThrough } from "stream"
+import { readAsync, sliceStream } from "../Utilities";
+
+let thru: PassThrough
+beforeEach(() => {
+    thru = new PassThrough();
+})
+
+describe('readAsync', function () {
+    it('returns immediately with results', async function () {
+        thru.write(Buffer.from([1, 2, 3]))
+        thru.write(Buffer.from([4, 5, 6]))
+
+        const result = await readAsync(thru)
+        expect(result).toEqual(Buffer.from([1, 2, 3, 4, 5, 6]))
+    })
+
+    it('to wait for data', async function () {
+        const resultPromise = readAsync(thru);
+
+        thru.write(Buffer.from([1, 2, 3]))
+        thru.write(Buffer.from([4, 5, 6]))
+
+        const result = await resultPromise;
+        expect(result).toEqual(Buffer.from([1, 2, 3]))
+    })
+
+    it('to return null at EOF', async function () {
+        thru.end()
+        expect(await readAsync(thru)).toBeNull()
+    })
+
+    it('to propagate errors', async function () {
+        const error = new Error('Mock error')
+        thru.destroy(error)
+        await expectAsync(readAsync(thru)).toBeRejectedWith(error);
+    })
+
+    it('bails on cancellation', async function () {
+        const cts = CancellationToken.create();
+        const readPromise = readAsync(thru, cts.token);
+        cts.cancel();
+        await expectAsync(readPromise).toBeRejected();
+    })
+})
+
+describe('sliceStream', function () {
+    it('returns null on empty', async function () {
+        thru.end()
+        const slice = sliceStream(thru, 5)
+        expect(slice.read()).toBeNull()
+    })
+
+    it('returns subset of upper stream', async function () {
+        thru.push(Buffer.from([1, 2, 3, 4, 5, 6]))
+        const slice = sliceStream(thru, 3)
+        expect(await readAsync(slice)).toEqual(Buffer.from([1, 2, 3]))
+        expect(await readAsync(slice)).toBeNull()
+        expect(await readAsync(thru)).toEqual(Buffer.from([4, 5, 6]))
+    })
+})

--- a/src/nerdbank-streams/yarn.lock
+++ b/src/nerdbank-streams/yarn.lock
@@ -1411,6 +1411,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==
 
+isstream@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
+  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
+
 jasmine-core@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-4.5.0.tgz#1a6bd0bde3f60996164311c88a0995d67ceda7c3"
@@ -1925,6 +1930,14 @@ pinkie@^2.0.0:
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==
 
+plexer@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/plexer/-/plexer-2.0.0.tgz#d5ff402f7fb79cce592101c193807d0b085ea41f"
+  integrity sha512-MWAhwDaaaNA9sfbZz00HjSxrwOxEUD8BW4pHG0obnjvJpyG3RcOjSIcDIQFW3NP+RDJlzPbyXdgCR3V24tyUdw==
+  dependencies:
+    isstream "^0.1.2"
+    readable-stream "^3.4.0"
+
 plugin-error@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/plugin-error/-/plugin-error-1.0.1.tgz#77016bd8919d0ac377fdcdd0322328953ca5781c"
@@ -2006,7 +2019,7 @@ readable-stream@1.1:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-"readable-stream@2 || 3":
+"readable-stream@2 || 3", readable-stream@^3.4.0:
   version "3.6.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.6.0.tgz#337bbda3adc0706bd3e024426a286d4b4b2c9198"
   integrity sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==


### PR DESCRIPTION
This PR is to fix problems that getBufferFrom keeps spinning and consumes lots of CPU, also leads product to hang.

This happens when the stream has partial data ready to read, because read(size) returns null (unless the stream is closed), but because there are unread data in the stream, the code will not block waiting on anything but immediately tries to read again. This would consume lots of CPU.  On the other hand, because the length of pipeline can be limited. when the reader wants a larger block over the size of the pipeline buffer, it would never get the data, because the writer cannot write any more data until reader takes some bytes out of the stream.

This PR is intended to use readableLength to read partial data out, and joins them on the reader side when it is necessary. However, the PR turns out to be more complicated due to this state is not defined in the ReadableStream interface, but in the implementation (Readable). Not sure why an important property like this is not included in the contract.  So the code lands to keep the old behavior unless readableLength is available.  Also, i kept running into memory issues in unit tests. There were some event handler which can leak memory, and was fixed. But it turned out that the real reason is that reableEnded can be false when streamEnded event is fired. Because the earlier changed code depends on the state, it ends up spinning in the function. Interestingly, it leads out of memory.