### PR TITLE
Reject acceptChannel promises on disposal

### DIFF
--- a/src/nerdbank-streams/src/tests/Timeout.ts
+++ b/src/nerdbank-streams/src/tests/Timeout.ts
@@ -5,14 +5,16 @@ export function timeout<T>(promise: Promise<T>, ms: number): Promise<T> {
 	const timer = setTimeout(() => {
 		deferred.reject('timeout expired')
 	}, ms)
-	promise.then(result => {
-		clearTimeout(timer)
-		deferred.resolve(result)
-	})
-	promise.catch(reason => {
-		clearTimeout(timer)
-		deferred.reject(reason)
-	})
+	promise.then(
+		result => {
+			clearTimeout(timer)
+			deferred.resolve(result)
+		},
+		reason => {
+			clearTimeout(timer)
+			deferred.reject(reason)
+		}
+	)
 	return deferred.promise
 }
 


### PR DESCRIPTION
We had been abandoning them up to this point. Once fixing that, it exposed another issue with an unobserved promise rejection in our tests which I fix as well.