### PR TITLE
Allow 0 length buffers in `ReadAsync` of `SimplexStream` and `HalfDuplexStream`

### DIFF
--- a/src/Nerdbank.Streams/HalfDuplexStream.cs
+++ b/src/Nerdbank.Streams/HalfDuplexStream.cs
@@ -91,7 +91,7 @@ namespace Nerdbank.Streams
             Requires.NotNull(buffer, nameof(buffer));
             Requires.Range(offset + count <= buffer.Length, nameof(count));
             Requires.Range(offset >= 0, nameof(offset));
-            Requires.Range(count > 0, nameof(count));
+            Requires.Range(count >= 0, nameof(count));
 
             ReadResult readResult = await this.pipe.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
             int bytesRead = 0;

--- a/src/Nerdbank.Streams/SimplexStream.cs
+++ b/src/Nerdbank.Streams/SimplexStream.cs
@@ -89,7 +89,7 @@ namespace Nerdbank.Streams
             Requires.NotNull(buffer, nameof(buffer));
             Requires.Range(offset + count <= buffer.Length, nameof(count));
             Requires.Range(offset >= 0, nameof(offset));
-            Requires.Range(count > 0, nameof(count));
+            Requires.Range(count >= 0, nameof(count));
 
             ReadResult readResult = await this.pipe.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
             int bytesRead = 0;

--- a/test/Nerdbank.Streams.Tests/HalfDuplexStreamTests.cs
+++ b/test/Nerdbank.Streams.Tests/HalfDuplexStreamTests.cs
@@ -232,6 +232,21 @@ public class HalfDuplexStreamTests : TestBase
         Assert.Equal(sendBuffer, recvBuffer);
     }
 
+    [Fact]
+    public async Task ReadAsync0LengthBufferThenWriteAsync()
+    {
+        byte[] sendBuffer = this.GetRandomBuffer(20);
+        byte[] recvBuffer = Array.Empty<byte>();
+        Task readTask = this.ReadAsync(this.stream, recvBuffer);
+        await this.stream.WriteAsync(sendBuffer, 0, sendBuffer.Length).WithCancellation(this.TimeoutToken);
+        await this.stream.FlushAsync(this.TimeoutToken);
+        await readTask.WithCancellation(this.TimeoutToken);
+
+        recvBuffer = new byte[sendBuffer.Length];
+        await this.ReadAsync(this.stream, recvBuffer);
+        Assert.Equal(sendBuffer, recvBuffer);
+    }
+
     [Theory]
     [CombinatorialData]
     public async Task CompleteWriting(bool useAsync)

--- a/test/Nerdbank.Streams.Tests/SimplexStreamTests.cs
+++ b/test/Nerdbank.Streams.Tests/SimplexStreamTests.cs
@@ -230,6 +230,21 @@ public class SimplexStreamTests : TestBase
         Assert.Equal(sendBuffer, recvBuffer);
     }
 
+    [Fact]
+    public async Task ReadAsync0LengthBufferThenWriteAsync()
+    {
+        byte[] sendBuffer = this.GetRandomBuffer(20);
+        byte[] recvBuffer = Array.Empty<byte>();
+        Task readTask = this.ReadAsync(this.stream, recvBuffer);
+        await this.stream.WriteAsync(sendBuffer, 0, sendBuffer.Length).WithCancellation(this.TimeoutToken);
+        await this.stream.FlushAsync(this.TimeoutToken);
+        await readTask.WithCancellation(this.TimeoutToken);
+
+        recvBuffer = new byte[sendBuffer.Length];
+        await this.ReadAsync(this.stream, recvBuffer);
+        Assert.Equal(sendBuffer, recvBuffer);
+    }
+
     [Theory]
     [CombinatorialData]
     public async Task CompleteWriting(bool useAsync)

--- a/test/Nerdbank.Streams.Tests/TestBase.cs
+++ b/test/Nerdbank.Streams.Tests/TestBase.cs
@@ -84,6 +84,9 @@ public abstract class TestBase : IDisposable
 
         if (count == 0)
         {
+            // Just read once and return.
+            int bytesJustRead = await stream.ReadAsync(buffer, offset, count.Value, this.TimeoutToken).WithCancellation(this.TimeoutToken);
+            Assert.Equal(0, bytesJustRead);
             return;
         }
 


### PR DESCRIPTION
Fixes #706