### PR TITLE
ci: declare contents:read on build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,9 @@ env:
   BUILDCONFIGURATION: Release
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages/
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: 🏭 Build


### PR DESCRIPTION
Sets `permissions: contents: read` at the top of `.github/workflows/build.yml`. The matrix build job clones with `fetch-depth: 0` (for nbgv versioning), installs the .NET prerequisites, builds and tests, then runs the local `publish-artifacts` composite action - which is just a series of `actions/upload-artifact` calls. Artifact upload writes to the run's own artifact scope and does not need `contents: write`. Codecov is uploaded via a separately stored `CODECOV_TOKEN` and bypasses `GITHUB_TOKEN`.

The reason for being explicit even when the inherited default may already be read-only is the runtime supply-chain threat surfaced by CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise): a tampered third-party action exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued. Per-workflow caps bound that authority irrespective of repo or org default, give drift protection if the default ever widens, and register with OpenSSF Scorecard's Token-Permissions check.

YAML validated locally with `yaml.safe_load`.
