### PR TITLE
Bundle dependency updates

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -30,7 +30,7 @@ jobs:
       with:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
     - name: Install gh-aw extension
-      uses: github/gh-aw-actions/setup-cli@268bf92726cb8153337c07166f382ee46e4fd897 # v0.78.2
+      uses: github/gh-aw-actions/setup-cli@5c2fe865bb4dc46e1450f6ee0d0541d759aea73a # v0.79.6
       with:
         version: v0.77.5
     - name: ⚙ Install prerequisites

--- a/.github/workflows/dependency-pr-bundler.lock.yml
+++ b/.github/workflows/dependency-pr-bundler.lock.yml
@@ -86,7 +86,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@268bf92726cb8153337c07166f382ee46e4fd897 # v0.78.2
+        uses: github/gh-aw-actions/setup@5c2fe865bb4dc46e1450f6ee0d0541d759aea73a # v0.79.6
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -351,7 +351,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@268bf92726cb8153337c07166f382ee46e4fd897 # v0.78.2
+        uses: github/gh-aw-actions/setup@5c2fe865bb4dc46e1450f6ee0d0541d759aea73a # v0.79.6
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1199,7 +1199,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@268bf92726cb8153337c07166f382ee46e4fd897 # v0.78.2
+        uses: github/gh-aw-actions/setup@5c2fe865bb4dc46e1450f6ee0d0541d759aea73a # v0.79.6
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1346,7 +1346,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@268bf92726cb8153337c07166f382ee46e4fd897 # v0.78.2
+        uses: github/gh-aw-actions/setup@5c2fe865bb4dc46e1450f6ee0d0541d759aea73a # v0.79.6
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
@@ -1586,7 +1586,7 @@ jobs:
     steps:
       - name: Setup Scripts
         id: setup
-        uses: github/gh-aw-actions/setup@268bf92726cb8153337c07166f382ee46e4fd897 # v0.78.2
+        uses: github/gh-aw-actions/setup@5c2fe865bb4dc46e1450f6ee0d0541d759aea73a # v0.79.6
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
     <MicrosoftTestingPlatformVersion>2.2.3</MicrosoftTestingPlatformVersion>
     <BenchmarkDotNetVersion>0.15.8</BenchmarkDotNetVersion>
-    <AspNetCoreVersion>2.3.10</AspNetCoreVersion>
+    <AspNetCoreVersion>2.3.11</AspNetCoreVersion>
     <VSThreadingVersion>17.14.15</VSThreadingVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,7 +14,7 @@
     <PackageVersion Include="BenchmarkDotNet" Version="$(BenchmarkDotNetVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(AspNetCoreVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore" Version="$(AspNetCoreVersion)" />
-    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.16" />
+    <PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.17" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Only" Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />

--- a/src/nerdbank-streams/package.json
+++ b/src/nerdbank-streams/package.json
@@ -35,7 +35,7 @@
     "@types/gulp": "4.0.18",
     "@types/jest": "30.0.0",
     "@types/msgpack-lite": "0.1.12",
-    "@types/node": "24.12.4",
+    "@types/node": "24.13.1",
     "@typescript-eslint/eslint-plugin": "8.60.1",
     "@typescript-eslint/parser": "8.60.1",
     "eslint": "10.4.1",

--- a/src/nerdbank-streams/yarn.lock
+++ b/src/nerdbank-streams/yarn.lock
@@ -872,12 +872,12 @@
   dependencies:
     undici-types ">=7.24.0 <7.24.7"
 
-"@types/node@24.12.4":
-  version "24.12.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.4.tgz#2709745569811dcbdc57c097fafdd387c6330382"
-  integrity sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==
+"@types/node@24.13.1":
+  version "24.13.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.13.1.tgz#890e6a3832959d8181a11c4c91c3a0de8410e697"
+  integrity sha512-RSpUJGmvsJ1ZeBehQZFhIdpsz+bIpES0nIQXko4Ybq+N+kX6XvOq3Jo+iJ82FWLdblFq85AsMikd3m35jgezYg==
   dependencies:
-    undici-types "~7.16.0"
+    undici-types "~7.18.0"
 
 "@types/picomatch@*":
   version "4.0.3"
@@ -5246,10 +5246,10 @@ undertaker@^2.0.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.24.6.tgz#61275b485d7fd4e9d269c7cf04ec2873c9cc0f91"
   integrity sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==
 
-undici-types@~7.16.0:
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
-  integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 unique-stream@^2.0.2:
   version "2.4.0"

--- a/tools/Set-EnvVars.ps1
+++ b/tools/Set-EnvVars.ps1
@@ -43,16 +43,36 @@ if ($env:GITHUB_ACTIONS) {
     Write-Host "GitHub Actions detected. Logging commands will be used to propagate environment variables and prepend path."
 }
 
-function Add-GitHubActionsFileCommand {
+function Add-GitHubActionsEnvVariable {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path,
         [Parameter(Mandatory = $true)]
-        [string]$Value
-    )
+       [string]$Name,
+       [Parameter(Mandatory = $true)]
+       [AllowEmptyString()]
+       [string]$Value
+   )
 
-    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
-    [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
+   if ([string]::IsNullOrWhiteSpace($Name)) {
+       throw "GitHub Actions environment variable names must not be empty."
+   }
+
+   $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+   $delimiter = [guid]::NewGuid().ToString('N')
+   [System.IO.File]::AppendAllText($Path, "$Name<<$delimiter`n$Value`n$delimiter`n", $utf8NoBom)
+}
+
+function Add-GitHubActionsPathCommand {
+   param(
+       [Parameter(Mandatory = $true)]
+       [string]$Path,
+       [Parameter(Mandatory = $true)]
+       [string]$Value
+   )
+
+   $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+   [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
 }
 
 $CmdEnvScript = ''
@@ -64,7 +84,7 @@ $Variables.GetEnumerator() |% {
         Write-Host "##vso[task.setvariable variable=$($_.Key);]$($_.Value)"
     }
     if ($env:GITHUB_ACTIONS) {
-        Add-GitHubActionsFileCommand -Path $env:GITHUB_ENV -Value "$($_.Key)=$($_.Value)"
+        Add-GitHubActionsEnvVariable -Path $env:GITHUB_ENV -Name $_.Key -Value ([string]$_.Value)
     }
 
     if ($cmdInstructions) {
@@ -91,7 +111,7 @@ if ($PrependPath) {
             Write-Host "##vso[task.prependpath]$_"
         }
         if ($env:GITHUB_ACTIONS) {
-            Add-GitHubActionsFileCommand -Path $env:GITHUB_PATH -Value $_
+            Add-GitHubActionsPathCommand -Path $env:GITHUB_PATH -Value $_
         }
 
         $CmdEnvScript += "SET PATH=$_$pathDelimiter%PATH%"

--- a/tools/variables/_define.ps1
+++ b/tools/variables/_define.ps1
@@ -11,16 +11,24 @@
 param (
 )
 
-function Add-GitHubActionsFileCommand {
+function Add-GitHubActionsEnvVariable {
     param(
         [Parameter(Mandatory = $true)]
         [string]$Path,
         [Parameter(Mandatory = $true)]
+        [string]$Name,
+        [Parameter(Mandatory = $true)]
+        [AllowEmptyString()]
         [string]$Value
     )
 
+    if ([string]::IsNullOrWhiteSpace($Name)) {
+        throw "GitHub Actions environment variable names must not be empty."
+    }
+
     $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
-    [System.IO.File]::AppendAllText($Path, "$Value`n", $utf8NoBom)
+    $delimiter = [guid]::NewGuid().ToString('N')
+    [System.IO.File]::AppendAllText($Path, "$Name<<$delimiter`n$Value`n$delimiter`n", $utf8NoBom)
 }
 
 (& "$PSScriptRoot\_all.ps1").GetEnumerator() |% {
@@ -36,7 +44,7 @@ function Add-GitHubActionsFileCommand {
             # and the second that works across jobs and stages but must be fully qualified when referenced.
             Write-Host "##vso[task.setvariable variable=$keyCaps;isOutput=true]$($_.Value)"
         } elseif ($env:GITHUB_ACTIONS) {
-            Add-GitHubActionsFileCommand -Path $env:GITHUB_ENV -Value "$keyCaps=$($_.Value)"
+            Add-GitHubActionsEnvVariable -Path $env:GITHUB_ENV -Name $keyCaps -Value ([string]$_.Value)
         }
         Set-Item -LiteralPath "env:$keyCaps" -Value $_.Value
     }


### PR DESCRIPTION
## Summary
- combine dependency updates from #1015, #1014, #1010, and #1009 into one branch
- include the GitHub Actions env-file handling fix needed for #1015 and #1009 to pass CI

## Included updates
- Update dotnet monorepo to 2.3.11
- Update .NET packages to 9.0.17
- Update dependency @types/node to v24.13.1
- Update github/gh-aw-actions action to v0.79.6

## Notes
- docfx-related checks were treated as non-blocking per the bundling instructions
