### PR TITLE
Fix PipeOptions settings

### DIFF
--- a/src/Nerdbank.Streams/MultiplexingStream.Channel.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.Channel.cs
@@ -761,7 +761,7 @@ namespace Nerdbank.Streams
 
                         var writerRelay = new Pipe();
                         Pipe? readerRelay = this.BackpressureSupportEnabled
-                            ? new Pipe(new PipeOptions(pauseWriterThreshold: this.localWindowSize.Value + 1)) // +1 prevents pause when remote window is exactly filled
+                            ? new Pipe(new PipeOptions(pauseWriterThreshold: this.localWindowSize.Value + 1, resumeWriterThreshold: this.localWindowSize.Value)) // +1 prevents pause when remote window is exactly filled
                             : new Pipe();
                         this.mxStreamIOReader = writerRelay.Reader;
                         this.mxStreamIOWriter = readerRelay.Writer;

--- a/test/Nerdbank.Streams.Tests/MultiplexingStreamV2Tests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStreamV2Tests.cs
@@ -136,6 +136,29 @@ public class MultiplexingStreamV2Tests : MultiplexingStreamTests
     }
 
     [Fact]
+    public async Task AcceptChannelAsync_SmallReceivingWindowSize()
+    {
+        const int offeredWindowSize = 16;
+        const int acceptedWindowSize = 64;
+
+        Task<MultiplexingStream.Channel> offeredChannelTask = this.mx1.OfferChannelAsync(
+            "small-window",
+            new MultiplexingStream.ChannelOptions { ChannelReceivingWindowSize = offeredWindowSize },
+            this.TimeoutToken);
+        Task<MultiplexingStream.Channel> acceptedChannelTask = this.mx2.AcceptChannelAsync(
+            "small-window",
+            new MultiplexingStream.ChannelOptions { ChannelReceivingWindowSize = acceptedWindowSize },
+            this.TimeoutToken);
+
+        MultiplexingStream.Channel[] channels = await WhenAllSucceedOrAnyFail(offeredChannelTask, acceptedChannelTask).WithCancellation(this.TimeoutToken);
+
+        await this.TransmitAndVerifyAsync(channels[0].AsStream(), channels[1].AsStream(), new byte[] { 1, 2, 3 });
+        await this.TransmitAndVerifyAsync(channels[1].AsStream(), channels[0].AsStream(), new byte[] { 4, 5, 6 });
+
+        await CompleteChannelsAsync(channels);
+    }
+
+    [Fact]
     public async Task Backpressure_CopyToAsync()
     {
         long backpressureThreshold = this.mx1.DefaultChannelReceivingWindowSize;


### PR DESCRIPTION
This was causing a failure in our interop tests that only showed up after updating System.IO.Pipelines.