### PR TITLE
Don't fail isolated tests when job object assignment fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
         submodules: true
     - name: ⚙ Install prerequisites
       run: |
-        ./init.ps1 -UpgradePrerequisites
+        ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
         dotnet --info
 
         # Print mono version if it is present.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
 
     - name: ⚙️ Install prerequisites
       run: |
-        ./init.ps1 -UpgradePrerequisites
+        ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
         dotnet --info
 
         # Print mono version if it is present.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
         submodules: true
     - name: ⚙ Install prerequisites
-      run: ./init.ps1 -UpgradePrerequisites
+      run: ./init.ps1 -UpgradePrerequisites -NoNuGetCredProvider
 
     - run: dotnet docfx docfx/docfx.json
       name: 📚 Generate documentation

--- a/test/Nerdbank.Streams.Tests/ProcessJobTracker.cs
+++ b/test/Nerdbank.Streams.Tests/ProcessJobTracker.cs
@@ -85,24 +85,35 @@ internal class ProcessJobTracker : IDisposable
     /// Ensures a given process is killed when the current process exits.
     /// </summary>
     /// <param name="process">The process whose lifetime should never exceed the lifetime of the current process.</param>
-    public void AddProcess(Process process)
+    /// <returns>The error that prevented the process from being added to the job; or <see langword="null"/> if the process was successfully added (or the OS has no job objects).</returns>
+    /// <remarks>
+    /// Job assignment is a best effort convenience for cleaning up child processes, and can fail for environmental
+    /// reasons that are outside the caller's control (e.g. the process already exited, or the process already belongs
+    /// to a job hierarchy that this job is not a part of). Callers should therefore treat a returned error
+    /// as a diagnostic warning rather than a failure.
+    /// </remarks>
+    public Exception? TryAddProcess(Process process)
     {
         Requires.NotNull(process, nameof(process));
 
         if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            return;
+            return null;
         }
 
-        bool success = AssignProcessToJobObject(this.jobHandle, new SafeObjectHandle(process.Handle, ownsHandle: false));
-        if (!success && !process.HasExited)
+        if (!AssignProcessToJobObject(this.jobHandle, new SafeObjectHandle(process.Handle, ownsHandle: false)))
         {
-            throw new Win32Exception();
+            // Capture the error code *immediately*, since any subsequent interop call
+            // (e.g. Process.HasExited) would overwrite it and lead to misleading diagnostics.
+            int errorCode = Marshal.GetLastWin32Error();
+            return new System.ComponentModel.Win32Exception(errorCode);
         }
+
+        return null;
     }
 
     /// <summary>
-    /// Kills all processes previously tracked with <see cref="AddProcess(Process)"/> by closing the Windows Job.
+    /// Kills all processes previously tracked with <see cref="TryAddProcess(Process)"/> by closing the Windows Job.
     /// </summary>
     public void Dispose()
     {

--- a/test/Nerdbank.Streams.Tests/TestBase.cs
+++ b/test/Nerdbank.Streams.Tests/TestBase.cs
@@ -276,7 +276,12 @@ public abstract class TestBase : IDisposable
 
         logger?.WriteLine("Test host launched with: \"{0}\" {1}", Path.GetFullPath(startInfo.FileName), startInfo.Arguments);
         Assert.True(isolatedTestProcess.Start());
-        this.processJobTracker.AddProcess(isolatedTestProcess);
+        if (this.processJobTracker.TryAddProcess(isolatedTestProcess) is Exception jobTrackingError)
+        {
+            // Job tracking is only a convenience for cleaning up the child process if this process dies unexpectedly.
+            // Its failure must not fail the test.
+            logger?.WriteLine("WARNING: Unable to add the isolated test host process to a job object: {0}", jobTrackingError);
+        }
 
         if (logger != null)
         {


### PR DESCRIPTION
The `MultiplexingStreamPerfTests` tests (net472 only) intermittently fail in CI — most recently in the merge queue run for #1120 ([run 30223830842](https://github.com/dotnet/Nerdbank.Streams/actions/runs/30223830842)) — with:

```
Xunit.MicrosoftTestingPlatform.XunitException: PInvoke.Win32Exception : The parameter is incorrect
   at ProcessJobTracker.AddProcess(Process process) in test/Nerdbank.Streams.Tests/ProcessJobTracker.cs:100
   at TestBase.ExecuteInIsolationAsync(...) in test/Nerdbank.Streams.Tests/TestBase.cs:281
```

This is unrelated to the pnpm bump in #1120.

Assigning the isolated test host process to a job object is only a best-effort safety net to kill orphaned child processes if the test process dies unexpectedly. It can fail for environmental reasons outside our control (e.g. the process already belongs to a job hierarchy that our job isn't part of, which can happen under the CI agent), so its failure should not fail the test. It is now logged as a warning instead.

Additionally, the Win32 error code is now captured immediately after the failed P/Invoke. The old code called `Process.HasExited` first, which issues its own interop calls and clobbers the last error — so the reported error code ("The parameter is incorrect") was likely bogus, obscuring the real cause.