### PR TITLE
Grow channel receiving windows on demand

### DIFF
--- a/src/Nerdbank.Streams/MultiplexingStream.Channel.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.Channel.cs
@@ -32,6 +32,12 @@ namespace Nerdbank.Streams
         public class Channel : IDisposableObservable, IDuplexPipe
         {
             /// <summary>
+            /// The maximum number of consecutive refusals that lengthen the delay before we ask
+            /// for a larger receiving window again, which caps the backoff at 2^this many stalls.
+            /// </summary>
+            private const int MaxWindowGrowthBackoffShift = 10;
+
+            /// <summary>
             /// This task source completes when the channel has been accepted, rejected, or the offer is canceled.
             /// </summary>
             private readonly TaskCompletionSource<AcceptanceParameters> acceptanceSource = new TaskCompletionSource<AcceptanceParameters>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -97,6 +103,67 @@ namespace Nerdbank.Streams
             /// or the value of <see cref="AcceptanceParameters.RemoteWindowSize"/> if we accepted the channel.
             /// </remarks>
             private long? localWindowSize;
+
+            /// <summary>
+            /// The number of bytes of window growth this channel has claimed from the stream-wide growth budget.
+            /// </summary>
+            /// <remarks>
+            /// All access to this field should be made within a lock on the <see cref="SyncObject"/> object.
+            /// </remarks>
+            private long reservedWindowGrowth;
+
+            /// <summary>
+            /// Our own <see cref="PipeReader"/> wrapper, when flow control is in use, so that we can observe
+            /// whether our reader is currently starved for data.
+            /// </summary>
+            private WindowPipeReader? windowPipeReader;
+
+            /// <summary>
+            /// A value indicating whether the remote party has asked us to enlarge our receiving window
+            /// and we have deferred the answer until our reader runs out of work.
+            /// </summary>
+            /// <remarks>
+            /// All access to this field should be made within a lock on the <see cref="SyncObject"/> object.
+            /// </remarks>
+            private bool windowGrowthRequestOutstanding;
+
+            /// <summary>
+            /// A value indicating whether we have asked the remote party to enlarge its receiving window
+            /// and have not yet been answered.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// This throttles growth requests to at most one in flight, so a channel spends at most one extra
+            /// frame per stall. The receiver answers every request, whether or not it agrees to grow.
+            /// </para>
+            /// <para>
+            /// All access to this field should be made within a lock on the <see cref="SyncObject"/> object.
+            /// </para>
+            /// </remarks>
+            private bool windowGrowthRequestPending;
+
+            /// <summary>
+            /// The number of consecutive growth requests that the remote party has declined.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// Each refusal doubles the number of stalls we must observe before asking again, so a channel that is
+            /// limited by its remote consumer rather than by its window quickly stops spending frames on requests
+            /// that will not be granted. A successful grant resets this to zero.
+            /// </para>
+            /// <para>
+            /// All access to this field should be made within a lock on the <see cref="SyncObject"/> object.
+            /// </para>
+            /// </remarks>
+            private int windowGrowthRefusals;
+
+            /// <summary>
+            /// The number of times we have run out of credit since we last asked for a larger window.
+            /// </summary>
+            /// <remarks>
+            /// All access to this field should be made within a lock on the <see cref="SyncObject"/> object.
+            /// </remarks>
+            private int stallsSinceWindowGrowthRequest;
 
             /// <summary>
             /// Indicates whether the <see cref="Dispose(Exception)"/> method has been called.
@@ -338,6 +405,24 @@ namespace Nerdbank.Streams
             private bool BackpressureSupportEnabled => this.MultiplexingStream.protocolMajorVersion > 1;
 
             /// <summary>
+            /// Gets a value indicating whether this channel may enlarge its own receiving window
+            /// in response to evidence that the remote sender is being throttled by it.
+            /// </summary>
+            /// <remarks>
+            /// <para>
+            /// Growth is negotiated entirely by the <see cref="ControlCode.ChannelWindowGrowthRequest"/> and
+            /// <see cref="ControlCode.ChannelWindowAdjust"/> frames, which are additive to the protocol: a peer that
+            /// predates them ignores them, so it simply never asks and is never granted. No version bump is required.
+            /// </para>
+            /// <para>
+            /// Protocol v1 has no flow control at all, so there is no window to grow.
+            /// </para>
+            /// </remarks>
+            private bool WindowAutoTuningEnabled =>
+                this.BackpressureSupportEnabled &&
+                this.MultiplexingStream.maxChannelReceivingWindowSize > this.localWindowSize;
+
+            /// <summary>
             /// Immediately terminates the channel and shuts down any ongoing communication.
             /// </summary>
             /// <remarks>
@@ -363,6 +448,16 @@ namespace Nerdbank.Streams
                     // First call to dispose
                     this.isDisposed = true;
                 }
+
+                // Return any window growth this channel had claimed so other channels may use it.
+                long growthToRelease;
+                lock (this.SyncObject)
+                {
+                    growthToRelease = this.reservedWindowGrowth;
+                    this.reservedWindowGrowth = 0;
+                }
+
+                this.MultiplexingStream.ReleaseWindowGrowth(growthToRelease);
 
                 this.acceptanceSource.TrySetCanceled();
                 this.optionsAppliedTaskSource?.TrySetCanceled();
@@ -666,6 +761,76 @@ namespace Nerdbank.Streams
             }
 
             /// <summary>
+            /// Invoked when the remote party reports that it has run out of credit on this channel and has more to send,
+            /// giving us the opportunity to enlarge the window we advertise to it.
+            /// </summary>
+            /// <remarks>
+            /// Growth is optional: declining is always correct and merely costs throughput. We answer either way,
+            /// repeating the current size when we decline, so that the remote party is free to ask again later.
+            /// </remarks>
+            internal void OnWindowGrowthRequested()
+            {
+                lock (this.SyncObject)
+                {
+                    if (this.windowPipeReader?.IsReadPending is not true)
+                    {
+                        // Our reader is busy with data we already have, so we cannot yet tell whether the window or
+                        // our own consumer is the constraint. Defer the answer until our reader runs out of work,
+                        // which is when the distinction becomes observable.
+                        this.windowGrowthRequestOutstanding = true;
+                        return;
+                    }
+                }
+
+                this.AnswerWindowGrowthRequest();
+            }
+
+            /// <summary>
+            /// Invoked when the remote party enlarges the receiving window it has advertised for this channel,
+            /// permitting us to have more unacknowledged bytes in flight to them.
+            /// </summary>
+            /// <param name="newWindowSize">The new (absolute) size of the remote party's receiving window.</param>
+            /// <remarks>
+            /// A window may only grow. A frame that would shrink it is ignored, since data may already be in flight
+            /// against the larger window and the sender cannot retract it.
+            /// </remarks>
+            internal void OnWindowAdjust(long newWindowSize)
+            {
+                Requires.Range(newWindowSize > 0, nameof(newWindowSize), "A positive number is required.");
+                lock (this.SyncObject)
+                {
+                    // Every growth request is answered, including a refusal, which repeats the current size.
+                    // Clearing the flag on either answer is what lets a channel ask again the next time it stalls.
+                    this.windowGrowthRequestPending = false;
+
+                    if (this.remoteWindowSize is not long currentSize || newWindowSize <= currentSize)
+                    {
+                        // A refusal. Back off exponentially so we stop spending frames on a channel
+                        // whose throughput is limited by its remote consumer rather than by its window.
+                        if (this.windowGrowthRefusals < MaxWindowGrowthBackoffShift)
+                        {
+                            this.windowGrowthRefusals++;
+                        }
+
+                        return;
+                    }
+
+                    this.windowGrowthRefusals = 0;
+
+                    this.remoteWindowSize = newWindowSize;
+                    if (this.remoteWindowFilled < newWindowSize)
+                    {
+                        this.remoteWindowHasCapacity.Set();
+                    }
+                }
+
+                if (this.TraceSource?.Switch.ShouldTrace(TraceEventType.Verbose) ?? false)
+                {
+                    this.TraceSource.TraceEvent(TraceEventType.Verbose, 0, "Remote receiving window grew to {0} bytes.", newWindowSize);
+                }
+            }
+
+            /// <summary>
             /// Invoked when the remote party acknowledges bytes we previously transmitted as processed,
             /// thereby allowing us to consider that data removed from the remote party's "window"
             /// and thus enables us to send more data to them.
@@ -792,12 +957,22 @@ namespace Nerdbank.Streams
                         }
 
                         var writerRelay = new Pipe();
+
+                        // When the window may grow later, the pipe must be created with room for the largest window
+                        // we could ever advertise, because a Pipe's pause threshold is fixed at construction.
+                        // This costs nothing until the space is used: the threshold is a limit, not an allocation.
+                        // The real bound on buffered data remains the flow control window, since the remote party
+                        // never sends more than the credit we have granted.
+                        long pauseThreshold = this.WindowAutoTuningEnabled
+                            ? this.MultiplexingStream.maxChannelReceivingWindowSize
+                            : this.localWindowSize.Value;
                         Pipe? readerRelay = this.BackpressureSupportEnabled
-                            ? new Pipe(new PipeOptions(pauseWriterThreshold: this.localWindowSize.Value + 1, resumeWriterThreshold: this.localWindowSize.Value)) // +1 prevents pause when remote window is exactly filled
+                            ? new Pipe(new PipeOptions(pauseWriterThreshold: pauseThreshold + 1, resumeWriterThreshold: pauseThreshold)) // +1 prevents pause when remote window is exactly filled
                             : new Pipe();
                         this.mxStreamIOReader = writerRelay.Reader;
                         this.mxStreamIOWriter = readerRelay.Writer;
-                        this.channelIO = new DuplexPipe(this.BackpressureSupportEnabled ? new WindowPipeReader(this, readerRelay.Reader) : readerRelay.Reader, writerRelay.Writer);
+                        this.windowPipeReader = this.BackpressureSupportEnabled ? new WindowPipeReader(this, readerRelay.Reader) : null;
+                        this.channelIO = new DuplexPipe((PipeReader?)this.windowPipeReader ?? readerRelay.Reader, writerRelay.Writer);
                     }
                 }
             }
@@ -831,9 +1006,17 @@ namespace Nerdbank.Streams
 
                     while (!this.Completion.IsCompleted)
                     {
-                        if (!this.remoteWindowHasCapacity.IsSet && this.TraceSource!.Switch.ShouldTrace(TraceEventType.Verbose))
+                        if (!this.remoteWindowHasCapacity.IsSet)
                         {
-                            this.TraceSource.TraceEvent(TraceEventType.Verbose, 0, "Remote window is full. Waiting for remote party to process data before sending more.");
+                            if (this.TraceSource!.Switch.ShouldTrace(TraceEventType.Verbose))
+                            {
+                                this.TraceSource.TraceEvent(TraceEventType.Verbose, 0, "Remote window is full. Waiting for remote party to process data before sending more.");
+                            }
+
+                            // We are about to be throttled by the remote party's receiving window.
+                            // Only the sender can observe this: a receiver that drains promptly never sees its own
+                            // buffer fill up, yet we may still be stalled here waiting for credit to make the round trip.
+                            this.RequestWindowGrowth();
                         }
 
                         await this.remoteWindowHasCapacity.WaitAsync().ConfigureAwait(false);
@@ -1000,6 +1183,110 @@ namespace Nerdbank.Streams
                     CancellationToken.None);
             }
 
+            /// <summary>
+            /// Invoked when our reader has drained everything we have and is waiting for more,
+            /// which is the moment a deferred window growth request can be judged.
+            /// </summary>
+            private void OnReaderStarved()
+            {
+                lock (this.SyncObject)
+                {
+                    if (!this.windowGrowthRequestOutstanding)
+                    {
+                        return;
+                    }
+
+                    this.windowGrowthRequestOutstanding = false;
+                }
+
+                this.AnswerWindowGrowthRequest();
+            }
+
+            /// <summary>
+            /// Answers an outstanding window growth request, growing the window if we can afford to.
+            /// </summary>
+            /// <remarks>
+            /// Only called when our reader is starved, which means it is idle waiting for data the sender is blocked
+            /// from giving it. Both ends are then stalled and only the window stands between them. Were our reader
+            /// instead behind, a larger window would buffer more unread data without moving any more of it, which is
+            /// the memory cost we are trying not to pay.
+            /// </remarks>
+            private void AnswerWindowGrowthRequest()
+            {
+                long newWindowSize;
+                bool grew = false;
+                lock (this.SyncObject)
+                {
+                    if (this.localWindowSize is not long currentSize)
+                    {
+                        return;
+                    }
+
+                    newWindowSize = currentSize;
+                    if (this.WindowAutoTuningEnabled)
+                    {
+                        long proposed = Math.Min(currentSize * 4, this.MultiplexingStream.maxChannelReceivingWindowSize);
+                        if (proposed > currentSize && this.MultiplexingStream.TryReserveWindowGrowth(proposed - currentSize))
+                        {
+                            this.localWindowSize = newWindowSize = proposed;
+                            this.reservedWindowGrowth += proposed - currentSize;
+                            grew = true;
+                        }
+                    }
+                }
+
+                this.MultiplexingStream.SendFrame(
+                    new FrameHeader
+                    {
+                        Code = ControlCode.ChannelWindowAdjust,
+                        ChannelId = this.QualifiedId,
+                    },
+                    this.MultiplexingStream.formatter.SerializeWindowSize(newWindowSize),
+                    CancellationToken.None);
+
+                if (grew && (this.TraceSource?.Switch.ShouldTrace(TraceEventType.Verbose) ?? false))
+                {
+                    this.TraceSource.TraceEvent(TraceEventType.Verbose, 0, "Local receiving window grew to {0} bytes.", newWindowSize);
+                }
+            }
+
+            /// <summary>
+            /// Asks the remote party to enlarge the receiving window it has advertised for this channel,
+            /// because we have run out of credit and have more to send.
+            /// </summary>
+            private void RequestWindowGrowth()
+            {
+                if (!this.BackpressureSupportEnabled || this.IsDisposed)
+                {
+                    return;
+                }
+
+                lock (this.SyncObject)
+                {
+                    if (this.windowGrowthRequestPending)
+                    {
+                        return;
+                    }
+
+                    if (++this.stallsSinceWindowGrowthRequest < 1 << this.windowGrowthRefusals)
+                    {
+                        return;
+                    }
+
+                    this.stallsSinceWindowGrowthRequest = 0;
+                    this.windowGrowthRequestPending = true;
+                }
+
+                this.MultiplexingStream.SendFrame(
+                    new FrameHeader
+                    {
+                        Code = ControlCode.ChannelWindowGrowthRequest,
+                        ChannelId = this.QualifiedId,
+                    },
+                    default,
+                    CancellationToken.None);
+            }
+
             private void LocalContentExamined(long bytesExamined)
             {
                 Requires.Range(bytesExamined >= 0, nameof(bytesExamined));
@@ -1160,8 +1447,8 @@ namespace Nerdbank.Streams
             {
                 private readonly Channel owner;
                 private readonly PipeReader inner;
-                private readonly long ackThreshold;
                 private ReadResult lastReadResult;
+                private int readsPending;
                 private long bytesProcessed;
                 private SequencePosition lastExaminedPosition;
 
@@ -1169,16 +1456,28 @@ namespace Nerdbank.Streams
                 {
                     this.owner = owner;
                     this.inner = inner;
-
-                    // Acknowledge in fractions of the window rather than in fixed-size frames.
-                    // Every acknowledgement costs a frame on the wire and a wake-up on both sides, so tying the
-                    // rate to the window keeps that cost proportional to the window instead of growing with it.
-                    // The frame length floor preserves the original behavior for small windows, and dividing
-                    // (rather than subtracting) guarantees the threshold never exceeds the window itself, so a
-                    // sender that has filled the window always earns credit once the reader drains it.
                     Assumes.True(owner.localWindowSize.HasValue);
-                    this.ackThreshold = Math.Max(FramePayloadMaxLength, owner.localWindowSize.Value / 8);
                 }
+
+                /// <summary>
+                /// Gets a value indicating whether our consumer is currently waiting inside a read,
+                /// which means it has drained everything we have and wants more.
+                /// </summary>
+                internal bool IsReadPending => Volatile.Read(ref this.readsPending) > 0;
+
+                /// <summary>
+                /// Gets the number of examined bytes that must accumulate before we spend a frame acknowledging them.
+                /// </summary>
+                /// <remarks>
+                /// Acknowledge in fractions of the window rather than in fixed-size frames.
+                /// Every acknowledgement costs a frame on the wire and a wake-up on both sides, so tying the
+                /// rate to the window keeps that cost proportional to the window instead of growing with it.
+                /// The frame length floor preserves the original behavior for small windows, and dividing
+                /// (rather than subtracting) guarantees the threshold never exceeds the window itself, so a
+                /// sender that has filled the window always earns credit once the reader drains it.
+                /// This is read fresh each time because the window may grow while the channel is in use.
+                /// </remarks>
+                private long AckThreshold => Math.Max(FramePayloadMaxLength, this.owner.localWindowSize!.Value / 8);
 
                 public override void AdvanceTo(SequencePosition consumed)
                 {
@@ -1202,9 +1501,18 @@ namespace Nerdbank.Streams
                     this.owner.LocalContentReadingCompleted();
                 }
 
-                public override async ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
+                public override ValueTask<ReadResult> ReadAsync(CancellationToken cancellationToken = default)
                 {
-                    return this.lastReadResult = await this.inner.ReadAsync(cancellationToken).ConfigureAwait(false);
+                    ValueTask<ReadResult> readTask = this.inner.ReadAsync(cancellationToken);
+                    if (readTask.IsCompletedSuccessfully)
+                    {
+                        // Data was already waiting, so our consumer is not starved and nothing needs to be reported.
+#pragma warning disable VSTHRD103 // The result is already available, so this does not block.
+                        return new ValueTask<ReadResult>(this.lastReadResult = readTask.Result);
+#pragma warning restore VSTHRD103
+                    }
+
+                    return this.AwaitStarvedReadAsync(readTask);
                 }
 
                 public override bool TryRead(out ReadResult readResult)
@@ -1222,6 +1530,20 @@ namespace Nerdbank.Streams
 
                 [Obsolete]
                 public override void OnWriterCompleted(Action<Exception?, object?> callback, object? state) => this.inner.OnWriterCompleted(callback, state);
+
+                private async ValueTask<ReadResult> AwaitStarvedReadAsync(ValueTask<ReadResult> readTask)
+                {
+                    Interlocked.Increment(ref this.readsPending);
+                    try
+                    {
+                        this.owner.OnReaderStarved();
+                        return this.lastReadResult = await readTask.ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref this.readsPending);
+                    }
+                }
 
                 private long Consumed(SequencePosition consumed, SequencePosition examined)
                 {
@@ -1243,7 +1565,7 @@ namespace Nerdbank.Streams
                     // to be worth a frame, or if our reader indicates that more data is required before it will examine any more.
                     // Or in some cases of very small receiving windows, when the entire window is empty.
                     long result = 0;
-                    if (this.bytesProcessed >= this.ackThreshold || this.bytesProcessed == this.owner.localWindowSize)
+                    if (this.bytesProcessed >= this.AckThreshold || this.bytesProcessed == this.owner.localWindowSize)
                     {
                         result = this.bytesProcessed;
                         this.bytesProcessed = 0;

--- a/src/Nerdbank.Streams/MultiplexingStream.ControlCode.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.ControlCode.cs
@@ -54,6 +54,30 @@ namespace Nerdbank.Streams
             /// Recipients that do not recognize this code ignore it.
             /// </remarks>
             ContentReadingCompleted,
+
+            /// <summary>
+            /// Sent by a channel's receiver to enlarge the receiving window it previously advertised,
+            /// permitting the remote party to have more unacknowledged bytes in flight.
+            /// </summary>
+            /// <remarks>
+            /// The payload carries the new (absolute) window size, which is only ever larger than the prior value.
+            /// This code is additive to the protocol rather than a new version of it: recipients that predate it
+            /// ignore it, which is safe because the window they already agreed to remains valid.
+            /// It is only ever sent in reply to a <see cref="ChannelWindowGrowthRequest"/>, so it is never sent
+            /// to a party that would not understand it.
+            /// </remarks>
+            ChannelWindowAdjust,
+
+            /// <summary>
+            /// Sent by a channel's sender when it has run out of credit and still has data to send,
+            /// asking the receiver to enlarge the window it advertises.
+            /// </summary>
+            /// <remarks>
+            /// This code is additive to the protocol rather than a new version of it. A receiver that predates it
+            /// ignores it and never replies, which costs one small frame per channel and leaves throughput
+            /// exactly where a fixed window would have left it.
+            /// </remarks>
+            ChannelWindowGrowthRequest,
         }
     }
 }

--- a/src/Nerdbank.Streams/MultiplexingStream.Formatters.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.Formatters.cs
@@ -96,6 +96,23 @@ namespace Nerdbank.Streams
 
             internal abstract ReadOnlySequence<byte> SerializeContentProcessed(long bytesProcessed);
 
+            /// <summary>
+            /// Serializes the payload of a <see cref="ControlCode.ChannelWindowAdjust"/> frame.
+            /// </summary>
+            /// <param name="windowSize">The new (absolute) size of the receiving window.</param>
+            /// <returns>The serialized payload.</returns>
+            /// <remarks>
+            /// The payload is a single integer, so it shares an encoding with <see cref="SerializeContentProcessed(long)"/>.
+            /// </remarks>
+            internal virtual ReadOnlySequence<byte> SerializeWindowSize(long windowSize) => this.SerializeContentProcessed(windowSize);
+
+            /// <summary>
+            /// Deserializes the payload of a <see cref="ControlCode.ChannelWindowAdjust"/> frame.
+            /// </summary>
+            /// <param name="payload">The payload to deserialize.</param>
+            /// <returns>The new (absolute) size of the receiving window.</returns>
+            internal virtual long DeserializeWindowSize(ReadOnlySequence<byte> payload) => this.DeserializeContentProcessed(payload);
+
             protected static bool IsOdd(ReadOnlySpan<byte> localRandomBuffer, ReadOnlySpan<byte> remoteRandomBuffer)
             {
                 bool? isOdd = null;

--- a/src/Nerdbank.Streams/MultiplexingStream.Options.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.Options.cs
@@ -54,6 +54,16 @@ namespace Nerdbank.Streams
             private long defaultChannelReceivingWindowSize = RecommendedDefaultChannelReceivingWindowSize;
 
             /// <summary>
+            /// Backing field for the <see cref="MaxChannelReceivingWindowSize"/> property.
+            /// </summary>
+            private long maxChannelReceivingWindowSize = 16 * RecommendedDefaultChannelReceivingWindowSize;
+
+            /// <summary>
+            /// Backing field for the <see cref="MaxTotalChannelReceivingWindowSize"/> property.
+            /// </summary>
+            private long maxTotalChannelReceivingWindowSize = 64 * RecommendedDefaultChannelReceivingWindowSize;
+
+            /// <summary>
             /// Backing field for the <see cref="DefaultChannelTraceSourceFactory"/> property.
             /// </summary>
             private Func<int, string, TraceSource?>? defaultChannelTraceSourceFactory;
@@ -91,6 +101,8 @@ namespace Nerdbank.Streams
                 Requires.NotNull(copyFrom, nameof(copyFrom));
 
                 this.defaultChannelReceivingWindowSize = copyFrom.defaultChannelReceivingWindowSize;
+                this.maxChannelReceivingWindowSize = copyFrom.maxChannelReceivingWindowSize;
+                this.maxTotalChannelReceivingWindowSize = copyFrom.maxTotalChannelReceivingWindowSize;
                 this.traceSource = copyFrom.traceSource;
                 this.protocolMajorVersion = copyFrom.protocolMajorVersion;
                 this.defaultChannelTraceSourceFactory = copyFrom.defaultChannelTraceSourceFactory;
@@ -153,6 +165,61 @@ namespace Nerdbank.Streams
             }
 
             /// <summary>
+            /// Gets or sets the largest value that <see cref="DefaultChannelReceivingWindowSize"/> may grow to
+            /// for an individual channel that demonstrates a need for it.
+            /// </summary>
+            /// <value>
+            /// Must be a positive value. The default is 16 times <see cref="DefaultChannelReceivingWindowSize"/>'s default value.
+            /// </value>
+            /// <exception cref="ArgumentOutOfRangeException">Thrown if set to a non-positive value.</exception>
+            /// <remarks>
+            /// <para>
+            /// This value is only used when <see cref="ProtocolMajorVersion"/> is at least 4, which adds the ability
+            /// for a receiver to enlarge a channel's receiving window after the channel has been established.
+            /// A channel's window only grows while its remote sender is actually blocked by it, so channels that never
+            /// saturate their window never consume more than <see cref="DefaultChannelReceivingWindowSize"/>.
+            /// </para>
+            /// <para>
+            /// Growth is additionally bounded across all channels by <see cref="MaxTotalChannelReceivingWindowSize"/>.
+            /// </para>
+            /// </remarks>
+            public long MaxChannelReceivingWindowSize
+            {
+                get => this.maxChannelReceivingWindowSize;
+                set
+                {
+                    Requires.Range(value > 0, nameof(value));
+                    this.ThrowIfFrozen();
+                    this.maxChannelReceivingWindowSize = value;
+                }
+            }
+
+            /// <summary>
+            /// Gets or sets the total number of bytes that all channels on this stream combined may commit to
+            /// receiving window growth beyond their initial <see cref="DefaultChannelReceivingWindowSize"/>.
+            /// </summary>
+            /// <value>
+            /// Must be a non-negative value. The default is 64 times <see cref="DefaultChannelReceivingWindowSize"/>'s default value.
+            /// </value>
+            /// <exception cref="ArgumentOutOfRangeException">Thrown if set to a negative value.</exception>
+            /// <remarks>
+            /// This value is only used when <see cref="ProtocolMajorVersion"/> is at least 4.
+            /// It bounds the worst case memory that automatic window growth may commit for the entire stream,
+            /// so that a stream with many busy channels cannot multiply <see cref="MaxChannelReceivingWindowSize"/>
+            /// by an unbounded number of channels.
+            /// </remarks>
+            public long MaxTotalChannelReceivingWindowSize
+            {
+                get => this.maxTotalChannelReceivingWindowSize;
+                set
+                {
+                    Requires.Range(value >= 0, nameof(value));
+                    this.ThrowIfFrozen();
+                    this.maxTotalChannelReceivingWindowSize = value;
+                }
+            }
+
+            /// <summary>
             /// Gets or sets the protocol version to be used.
             /// </summary>
             /// <value>The default is 1.</value>
@@ -160,6 +227,7 @@ namespace Nerdbank.Streams
             /// 1 is the original and default version.
             /// 2 is a protocol breaking change and adds backpressure support.
             /// 3 is a protocol breaking change that removes the initial handshake so no round-trip to establish the connection is necessary.
+            /// 4 is a protocol breaking change that allows a receiver to enlarge a channel's receiving window after the channel is established.
             /// </remarks>
             public int ProtocolMajorVersion
             {

--- a/src/Nerdbank.Streams/MultiplexingStream.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.cs
@@ -120,10 +120,24 @@ namespace Nerdbank.Streams
         private readonly int protocolMajorVersion;
 
         /// <summary>
+        /// The largest receiving window any single channel may grow to via <see cref="ControlCode.ChannelWindowAdjust"/>.
+        /// </summary>
+        private readonly long maxChannelReceivingWindowSize;
+
+        /// <summary>
         /// A value indicating whether any open channels should be faulted (i.e. their <see cref="Channel.Completion"/> task will be faulted)
         /// when the <see cref="MultiplexingStream"/> is disposed.
         /// </summary>
         private readonly bool faultOpenChannelsOnStreamDisposal;
+
+        /// <summary>
+        /// The number of bytes of receiving window growth (beyond each channel's initial window)
+        /// that remain available to be committed across all channels of this stream.
+        /// </summary>
+        /// <remarks>
+        /// Accessed only via <see cref="TryReserveWindowGrowth(long)"/> and <see cref="ReleaseWindowGrowth(long)"/>.
+        /// </remarks>
+        private long remainingWindowGrowthBudget;
 
         /// <summary>
         /// The last number assigned to a channel.
@@ -162,6 +176,8 @@ namespace Nerdbank.Streams
 
             this.DefaultChannelReceivingWindowSize = options.DefaultChannelReceivingWindowSize;
             this.protocolMajorVersion = options.ProtocolMajorVersion;
+            this.maxChannelReceivingWindowSize = Math.Max(options.MaxChannelReceivingWindowSize, options.DefaultChannelReceivingWindowSize);
+            this.remainingWindowGrowthBudget = options.MaxTotalChannelReceivingWindowSize;
 
             // Set up seed channels
             for (int i = 0; i < options.SeededChannels.Count; i++)
@@ -866,6 +882,12 @@ namespace Nerdbank.Streams
                         case ControlCode.ContentProcessed:
                             this.OnContentProcessed(header, frame.Value.Payload);
                             break;
+                        case ControlCode.ChannelWindowAdjust:
+                            this.OnChannelWindowAdjust(header, frame.Value.Payload);
+                            break;
+                        case ControlCode.ChannelWindowGrowthRequest:
+                            this.OnChannelWindowGrowthRequest(header);
+                            break;
                         case ControlCode.ContentWritingCompleted:
                             this.OnContentWritingCompleted(header.RequiredChannelId);
                             break;
@@ -1084,6 +1106,72 @@ namespace Nerdbank.Streams
 
             long bytesProcessed = this.formatter.DeserializeContentProcessed(payloadBuffer);
             channel.OnContentProcessed(bytesProcessed);
+        }
+
+        private void OnChannelWindowAdjust(FrameHeader header, ReadOnlySequence<byte> payloadBuffer)
+        {
+            Channel? channel;
+            lock (this.syncObject)
+            {
+                this.openChannels.TryGetValue(header.RequiredChannelId, out channel);
+            }
+
+            if (channel is null)
+            {
+                // The channel closed concurrently with the remote party's decision to enlarge its window.
+                // Dropping the adjustment is safe: there is nothing left to send.
+                return;
+            }
+
+            long newWindowSize = this.formatter.DeserializeWindowSize(payloadBuffer);
+            channel.OnWindowAdjust(newWindowSize);
+        }
+
+        private void OnChannelWindowGrowthRequest(FrameHeader header)
+        {
+            Channel? channel;
+            lock (this.syncObject)
+            {
+                this.openChannels.TryGetValue(header.RequiredChannelId, out channel);
+            }
+
+            // A request for a channel that has since closed needs no answer.
+            channel?.OnWindowGrowthRequested();
+        }
+
+        /// <summary>
+        /// Attempts to claim a portion of this stream's total budget for receiving window growth.
+        /// </summary>
+        /// <param name="bytes">The number of additional bytes of window the caller wants to commit to.</param>
+        /// <returns><see langword="true"/> if the budget had room and has been debited; otherwise <see langword="false"/>.</returns>
+        private bool TryReserveWindowGrowth(long bytes)
+        {
+            long remaining = Volatile.Read(ref this.remainingWindowGrowthBudget);
+            while (remaining >= bytes)
+            {
+                long candidate = Interlocked.CompareExchange(ref this.remainingWindowGrowthBudget, remaining - bytes, remaining);
+                if (candidate == remaining)
+                {
+                    return true;
+                }
+
+                remaining = candidate;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns window growth budget previously claimed by <see cref="TryReserveWindowGrowth(long)"/>,
+        /// so that other channels may use it after a channel closes.
+        /// </summary>
+        /// <param name="bytes">The number of bytes to return to the budget.</param>
+        private void ReleaseWindowGrowth(long bytes)
+        {
+            if (bytes > 0)
+            {
+                Interlocked.Add(ref this.remainingWindowGrowthBudget, bytes);
+            }
         }
 
         private void OnOffer(QualifiedChannelId channelId, ReadOnlySequence<byte> payloadBuffer)

--- a/test/Nerdbank.Streams.Benchmark/LatencyBulkTransferBenchmark.cs
+++ b/test/Nerdbank.Streams.Benchmark/LatencyBulkTransferBenchmark.cs
@@ -1,0 +1,116 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.Streams.Benchmark
+{
+    using System;
+    using System.IO;
+    using System.IO.Pipelines;
+    using System.Threading.Tasks;
+    using BenchmarkDotNet.Attributes;
+
+    /// <summary>
+    /// Measures bulk transfer over a transport with artificial latency.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The other benchmarks all run over loopback, where a round trip is essentially free. That makes
+    /// them blind to the central trade-off in the receive window's flow control: returning credit less
+    /// often costs fewer frames but makes the sender wait a full round trip when it does run out.
+    /// On loopback the second half of that trade-off is invisible, so tuning against loopback alone
+    /// will happily pick a setting that behaves badly on a real network.
+    /// </para>
+    /// <para>
+    /// Throughput here is expected to approach the window divided by the round trip time whenever the
+    /// window is the binding constraint, so the interesting signal is how much larger a window must be
+    /// as latency grows.
+    /// </para>
+    /// </remarks>
+    public class LatencyBulkTransferBenchmark : MultiplexingStreamBenchmarkBase
+    {
+        private byte[] payload = null!;
+
+        /// <summary>
+        /// Gets or sets the one-way delay applied to the transport, in milliseconds.
+        /// </summary>
+        /// <remarks>
+        /// The round trip time is twice this. Zero disables the wrapper entirely, giving a
+        /// direct comparison against the plain loopback benchmarks. The platform timer cannot
+        /// faithfully reproduce delays below about a millisecond, so no smaller value is offered.
+        /// </remarks>
+        [Params(0, 1, 8)]
+        public int OneWayLatencyMs { get; set; }
+
+        /// <summary>
+        /// Gets or sets the receiving window size to configure, or 0 to use the default.
+        /// </summary>
+        [Params(0, 4 * 1024 * 1024)]
+        public int WindowSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of bytes to transfer.
+        /// </summary>
+        /// <remarks>
+        /// This is much smaller than the loopback benchmarks use, because a latent connection
+        /// takes far longer to move the same volume.
+        /// </remarks>
+        [Params(4 * 1024 * 1024)]
+        public int TransferSize { get; set; }
+
+        /// <summary>
+        /// Transfers <see cref="TransferSize"/> bytes over a single channel.
+        /// </summary>
+        /// <returns>A task that tracks the transfer.</returns>
+        [Benchmark]
+        public async Task TransmitBulkData()
+        {
+            (MultiplexingStream.Channel sender, MultiplexingStream.Channel receiver) = await this.CreateChannelAsync(Guid.NewGuid().ToString("n"));
+
+            Task writeTask = Task.Run(async delegate
+            {
+                await sender.Output.WriteAsync(this.payload);
+                await sender.Output.CompleteAsync();
+            });
+
+            long bytesRead = 0;
+            while (bytesRead < this.TransferSize)
+            {
+                ReadResult readResult = await receiver.Input.ReadAsync();
+                if (readResult.Buffer.IsEmpty && readResult.IsCompleted)
+                {
+                    break;
+                }
+
+                bytesRead += readResult.Buffer.Length;
+                receiver.Input.AdvanceTo(readResult.Buffer.End);
+            }
+
+            await writeTask;
+            sender.Dispose();
+            receiver.Dispose();
+        }
+
+        /// <inheritdoc/>
+        protected override MultiplexingStream.Options CreateOptions()
+        {
+            MultiplexingStream.Options options = base.CreateOptions();
+            if (this.WindowSize > 0)
+            {
+                options.DefaultChannelReceivingWindowSize = this.WindowSize;
+            }
+
+            return options;
+        }
+
+        /// <inheritdoc/>
+        protected override Stream WrapTransport(Stream transport)
+            => this.OneWayLatencyMs == 0 ? transport : new LatencyStream(transport, TimeSpan.FromMilliseconds(this.OneWayLatencyMs));
+
+        /// <inheritdoc/>
+        protected override Task OnConnectedAsync()
+        {
+            this.payload = new byte[this.TransferSize];
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Benchmark/LatencyStream.cs
+++ b/test/Nerdbank.Streams.Benchmark/LatencyStream.cs
@@ -1,0 +1,213 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.Streams.Benchmark
+{
+    using System;
+    using System.Buffers;
+    using System.Collections.Concurrent;
+    using System.Diagnostics;
+    using System.IO;
+    using System.IO.Pipelines;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Wraps a stream so that data becomes readable only after a fixed one-way delay,
+    /// simulating a network with meaningful latency.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Writes pass straight through; the delay is applied on the reading side. Wrapping both ends
+    /// of a connection therefore delays each direction once, producing a round trip time of twice
+    /// the configured one-way delay.
+    /// </para>
+    /// <para>
+    /// Delayed data is held in a queue and released by a background pump, so transfers remain
+    /// pipelined: throughput is limited by the sender and the flow control window rather than by
+    /// the delay applied to any single chunk. Simply awaiting before returning from each read
+    /// would instead serialize the connection and cap throughput at one chunk per delay.
+    /// </para>
+    /// <para>
+    /// Accuracy is bounded by the platform timer, so delays below about a millisecond are not
+    /// faithfully reproduced. This class is meant for comparing configurations at the same
+    /// configured latency, not for predicting absolute throughput on a real network.
+    /// </para>
+    /// </remarks>
+    internal sealed class LatencyStream : Stream
+    {
+        private readonly Stream inner;
+        private readonly long delayTicks;
+        private readonly Pipe delayed = new Pipe();
+        private readonly Stream delayedReader;
+        private readonly ConcurrentQueue<(long DueTimestamp, byte[] Buffer, int Length)> queue = new ConcurrentQueue<(long, byte[], int)>();
+        private readonly SemaphoreSlim queueSignal = new SemaphoreSlim(0);
+        private readonly CancellationTokenSource disposalSource = new CancellationTokenSource();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LatencyStream"/> class.
+        /// </summary>
+        /// <param name="inner">The underlying transport.</param>
+        /// <param name="oneWayDelay">How long to withhold data that arrives on <paramref name="inner"/>.</param>
+        internal LatencyStream(Stream inner, TimeSpan oneWayDelay)
+        {
+            this.inner = inner;
+            this.delayTicks = (long)(oneWayDelay.TotalSeconds * Stopwatch.Frequency);
+            this.delayedReader = this.delayed.Reader.AsStream();
+
+            Task.Run(this.ReceivePumpAsync);
+            Task.Run(this.ReleasePumpAsync);
+        }
+
+        /// <inheritdoc/>
+        public override bool CanRead => true;
+
+        /// <inheritdoc/>
+        public override bool CanSeek => false;
+
+        /// <inheritdoc/>
+        public override bool CanWrite => true;
+
+        /// <inheritdoc/>
+        public override long Length => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        /// <inheritdoc/>
+        public override void Flush() => this.inner.Flush();
+
+        /// <inheritdoc/>
+        public override Task FlushAsync(CancellationToken cancellationToken) => this.inner.FlushAsync(cancellationToken);
+
+        /// <inheritdoc/>
+        public override int Read(byte[] buffer, int offset, int count) => this.delayedReader.Read(buffer, offset, count);
+
+        /// <inheritdoc/>
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => this.delayedReader.ReadAsync(buffer, offset, count, cancellationToken);
+
+        /// <inheritdoc/>
+        public override void Write(byte[] buffer, int offset, int count) => this.inner.Write(buffer, offset, count);
+
+        /// <inheritdoc/>
+        public override Task WriteAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+            => this.inner.WriteAsync(buffer, offset, count, cancellationToken);
+
+        /// <inheritdoc/>
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        /// <inheritdoc/>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.disposalSource.Cancel();
+                this.inner.Dispose();
+                this.delayedReader.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        /// <summary>
+        /// Waits until the given timestamp has passed, sleeping when the remaining time exceeds
+        /// the timer's useful resolution and yielding otherwise.
+        /// </summary>
+        /// <param name="dueTimestamp">The <see cref="Stopwatch.GetTimestamp"/> value to wait for.</param>
+        /// <returns>A task that completes once the timestamp has passed.</returns>
+        private static async Task WaitUntilAsync(long dueTimestamp)
+        {
+            while (true)
+            {
+                double remainingMs = (dueTimestamp - Stopwatch.GetTimestamp()) * 1000.0 / Stopwatch.Frequency;
+                if (remainingMs <= 0)
+                {
+                    return;
+                }
+
+                if (remainingMs > 2)
+                {
+                    await Task.Delay(TimeSpan.FromMilliseconds(remainingMs - 1)).ConfigureAwait(false);
+                }
+                else
+                {
+                    await Task.Yield();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Continuously moves data off the transport and stamps it with the time it may be released,
+        /// so that reading is never blocked behind an earlier chunk's delay.
+        /// </summary>
+        /// <returns>A task that completes when the transport is exhausted.</returns>
+        private async Task ReceivePumpAsync()
+        {
+            try
+            {
+                while (!this.disposalSource.IsCancellationRequested)
+                {
+                    // Each chunk must survive until its release time, so it cannot share one buffer.
+                    // Pooling keeps this harness from allocating the entire transfer volume, which
+                    // would otherwise show up as GC pressure in the measurements it is meant to inform.
+                    byte[] chunk = ArrayPool<byte>.Shared.Rent(64 * 1024);
+                    int bytesRead = await this.inner.ReadAsync(chunk, 0, chunk.Length, this.disposalSource.Token).ConfigureAwait(false);
+                    if (bytesRead == 0)
+                    {
+                        ArrayPool<byte>.Shared.Return(chunk);
+                        break;
+                    }
+
+                    this.queue.Enqueue((Stopwatch.GetTimestamp() + this.delayTicks, chunk, bytesRead));
+                    this.queueSignal.Release();
+                }
+            }
+            catch (Exception ex)
+            {
+                this.delayed.Writer.Complete(ex);
+                return;
+            }
+
+            this.delayed.Writer.Complete();
+        }
+
+        /// <summary>
+        /// Releases queued data to the reader once each chunk's delay has elapsed.
+        /// </summary>
+        /// <returns>A task that completes when the stream is disposed.</returns>
+        private async Task ReleasePumpAsync()
+        {
+            try
+            {
+                while (!this.disposalSource.IsCancellationRequested)
+                {
+                    await this.queueSignal.WaitAsync(this.disposalSource.Token).ConfigureAwait(false);
+                    if (!this.queue.TryDequeue(out (long DueTimestamp, byte[] Buffer, int Length) item))
+                    {
+                        continue;
+                    }
+
+                    await WaitUntilAsync(item.DueTimestamp).ConfigureAwait(false);
+                    await this.delayed.Writer.WriteAsync(new ReadOnlyMemory<byte>(item.Buffer, 0, item.Length), this.disposalSource.Token).ConfigureAwait(false);
+                    ArrayPool<byte>.Shared.Return(item.Buffer);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Disposed.
+            }
+            catch (Exception ex)
+            {
+                this.delayed.Writer.Complete(ex);
+            }
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Benchmark/MultiplexingStreamBenchmarkBase.cs
+++ b/test/Nerdbank.Streams.Benchmark/MultiplexingStreamBenchmarkBase.cs
@@ -76,6 +76,17 @@ namespace Nerdbank.Streams.Benchmark
         protected virtual Task OnConnectedAsync() => Task.CompletedTask;
 
         /// <summary>
+        /// Wraps each end of the transport before the multiplexing streams are built on top of it.
+        /// </summary>
+        /// <param name="transport">One end of the loopback connection.</param>
+        /// <returns>The stream the multiplexing stream should use.</returns>
+        /// <remarks>
+        /// The default implementation returns <paramref name="transport"/> unchanged. Derived classes
+        /// override this to interpose behavior such as artificial latency.
+        /// </remarks>
+        protected virtual Stream WrapTransport(Stream transport) => transport;
+
+        /// <summary>
         /// Opens a channel with a unique name on both ends of the connection.
         /// </summary>
         /// <param name="name">A name that has not been used on this connection before.</param>
@@ -108,8 +119,8 @@ namespace Nerdbank.Streams.Benchmark
             this.client.NoDelay = true;
             this.server.NoDelay = true;
 
-            Stream clientStream = this.client.GetStream();
-            Stream serverStream = this.server.GetStream();
+            Stream clientStream = this.WrapTransport(this.client.GetStream());
+            Stream serverStream = this.WrapTransport(this.server.GetStream());
 
             Task<MultiplexingStream> mx1Task = MultiplexingStream.CreateAsync(clientStream, this.CreateOptions());
             Task<MultiplexingStream> mx2Task = MultiplexingStream.CreateAsync(serverStream, this.CreateOptions());

--- a/test/Nerdbank.Streams.Benchmark/Program.cs
+++ b/test/Nerdbank.Streams.Benchmark/Program.cs
@@ -17,6 +17,7 @@ namespace Nerdbank.Streams.Benchmark
                 typeof(DuplexMessagingBenchmark),
                 typeof(ContendedChannelsBenchmark),
                 typeof(ChannelLifetimeBenchmark),
+                typeof(LatencyBulkTransferBenchmark),
             });
             switcher.Run(args);
         }

--- a/test/Nerdbank.Streams.Tests/MultiplexingStreamV2Tests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStreamV2Tests.cs
@@ -325,4 +325,148 @@ public class MultiplexingStreamV2Tests : MultiplexingStreamTests
         await writeTask.WithCancellation(this.TimeoutToken);
         Assert.Equal(bytesToSend, bytesRead);
     }
+
+    /// <summary>
+    /// Verifies that a channel whose sender is repeatedly throttled by the receiving window
+    /// ends up with a larger window than it started with.
+    /// </summary>
+    [Fact]
+    public async Task WindowGrows_WhenSenderIsThrottled()
+    {
+        long initialWindow = this.mx1.DefaultChannelReceivingWindowSize;
+        (MultiplexingStream.Channel a, MultiplexingStream.Channel b) = await this.EstablishChannelsAsync("a");
+
+        await this.ThrottleSenderAsync(a, b, initialWindow, rounds: 2);
+
+        // With no reader draining it, the amount that can be written before the flush blocks is bounded by
+        // the receiving window. Twice the original window would not have fit before the channel grew.
+        a.Output.Write(new byte[initialWindow * 2]);
+        await a.Output.FlushAsync(this.TimeoutToken).AsTask().WithCancellation(this.TimeoutToken);
+
+        await this.DrainAsync(b.Input, initialWindow * 2);
+        await CompleteChannelsAsync(a, b);
+    }
+
+    /// <summary>
+    /// Verifies that window growth stops at <see cref="MultiplexingStream.Options.MaxChannelReceivingWindowSize"/>.
+    /// </summary>
+    [Fact]
+    public async Task WindowGrowth_IsCappedPerChannel()
+    {
+        await this.ReinitializeMxStreamsAsync(new MultiplexingStream.Options
+        {
+            MaxChannelReceivingWindowSize = 2 * new MultiplexingStream.Options().DefaultChannelReceivingWindowSize,
+        });
+
+        long initialWindow = this.mx1.DefaultChannelReceivingWindowSize;
+        (MultiplexingStream.Channel a, MultiplexingStream.Channel b) = await this.EstablishChannelsAsync("a");
+
+        await this.ThrottleSenderAsync(a, b, initialWindow, rounds: 2);
+
+        // The window may have doubled once, but no further, so this must not fit.
+        a.Output.Write(new byte[initialWindow * 4]);
+        Task flushTask = a.Output.FlushAsync(this.TimeoutToken).AsTask();
+        await Task.Delay(ExpectedTimeout);
+        Assert.False(flushTask.IsCompleted);
+
+        await this.DrainAsync(b.Input, initialWindow * 4);
+        await flushTask.WithCancellation(this.TimeoutToken);
+        await CompleteChannelsAsync(a, b);
+    }
+
+    /// <summary>
+    /// Verifies that the stream-wide growth budget can veto growth that the channel would otherwise take,
+    /// which is what bounds the memory a stream with many busy channels may commit.
+    /// </summary>
+    [Fact]
+    public async Task WindowDoesNotGrow_WhenStreamBudgetIsExhausted()
+    {
+        await this.ReinitializeMxStreamsAsync(new MultiplexingStream.Options
+        {
+            MaxTotalChannelReceivingWindowSize = 0,
+        });
+
+        long initialWindow = this.mx1.DefaultChannelReceivingWindowSize;
+        (MultiplexingStream.Channel a, MultiplexingStream.Channel b) = await this.EstablishChannelsAsync("a");
+
+        await this.ThrottleSenderAsync(a, b, initialWindow, rounds: 2);
+
+        // Without budget, the channel must still behave exactly as it does on v3.
+        a.Output.Write(new byte[initialWindow * 2]);
+        Task flushTask = a.Output.FlushAsync(this.TimeoutToken).AsTask();
+        await Task.Delay(ExpectedTimeout);
+        Assert.False(flushTask.IsCompleted);
+
+        await this.DrainAsync(b.Input, initialWindow * 2);
+        await flushTask.WithCancellation(this.TimeoutToken);
+        await CompleteChannelsAsync(a, b);
+    }
+
+    /// <summary>
+    /// Verifies that a channel that never fills its window is left at its original size,
+    /// so that idle or low-rate channels do not consume the stream's growth budget.
+    /// </summary>
+    [Fact]
+    public async Task WindowDoesNotGrow_ForUnsaturatedChannel()
+    {
+        long initialWindow = this.mx1.DefaultChannelReceivingWindowSize;
+        (MultiplexingStream.Channel a, MultiplexingStream.Channel b) = await this.EstablishChannelsAsync("a");
+
+        // Transfer well over a window's worth of data in small pieces, draining after each one
+        // so the window is never anywhere near full.
+        byte[] smallChunk = new byte[initialWindow / 16];
+        for (int i = 0; i < 32; i++)
+        {
+            a.Output.Write(smallChunk);
+            await a.Output.FlushAsync(this.TimeoutToken);
+            await this.DrainAsync(b.Input, smallChunk.Length);
+        }
+
+        // The window should not have grown, so twice the original window must not fit.
+        a.Output.Write(new byte[initialWindow * 2]);
+        Task flushTask = a.Output.FlushAsync(this.TimeoutToken).AsTask();
+        await Task.Delay(ExpectedTimeout);
+        Assert.False(flushTask.IsCompleted);
+
+        await this.DrainAsync(b.Input, initialWindow * 2);
+        await flushTask.WithCancellation(this.TimeoutToken);
+        await CompleteChannelsAsync(a, b);
+    }
+
+    /// <summary>
+    /// Repeatedly writes more than the receiving window and only then drains it, which guarantees the
+    /// receiver observes a sender that is blocked on flow control.
+    /// </summary>
+    /// <param name="sender">The channel to write to.</param>
+    /// <param name="receiver">The channel to read from.</param>
+    /// <param name="window">The receiving window size that the channel started with.</param>
+    /// <param name="rounds">The number of times to saturate and drain the window.</param>
+    /// <returns>A task that completes when the transfers are done.</returns>
+    private async Task ThrottleSenderAsync(MultiplexingStream.Channel sender, MultiplexingStream.Channel receiver, long window, int rounds)
+    {
+        for (int i = 0; i < rounds; i++)
+        {
+            // The window grows by a factor of 4 on each successful round, so scale what we write to match,
+            // ensuring the sender is still throttled no matter how much it grew last time.
+            long writeSize = (window * 2) << (2 * i);
+            sender.Output.Write(new byte[writeSize]);
+            Task flushTask = sender.Output.FlushAsync(this.TimeoutToken).AsTask();
+
+            // Let the sender run out of credit before anyone reads, so that it reliably asks for a larger window.
+            await Task.Delay(ExpectedTimeout);
+            Assert.False(flushTask.IsCompleted);
+
+            await this.DrainAsync(receiver.Input, writeSize);
+            await flushTask.WithCancellation(this.TimeoutToken);
+
+            // A growth request is only judged when the receiving side's reader runs out of work, since that is
+            // the moment it becomes clear that the window rather than the consumer is the constraint.
+            // Issue a read that cannot be satisfied so that moment arrives deterministically.
+            Task<ReadResult> starvedRead = receiver.Input.ReadAsync(this.TimeoutToken).AsTask();
+            await Task.Delay(ExpectedTimeout);
+            receiver.Input.CancelPendingRead();
+            ReadResult readResult = await starvedRead.WithCancellation(this.TimeoutToken);
+            receiver.Input.AdvanceTo(readResult.Buffer.Start);
+        }
+    }
 }

--- a/test/Nerdbank.Streams.Tests/MultiplexingStreamWindowFrameCompatTests.cs
+++ b/test/Nerdbank.Streams.Tests/MultiplexingStreamWindowFrameCompatTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Buffers;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using MessagePack;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank.Streams;
+using Xunit;
+
+/// <summary>
+/// Verifies that the window tuning frames are purely additive to the protocol, by simulating a peer
+/// that predates them and therefore silently ignores them.
+/// </summary>
+/// <remarks>
+/// This is the premise the whole feature rests on: because both the .NET and JS implementations dispatch
+/// frames through a <c>default:</c> case that ignores unrecognized control codes, and because frames are
+/// self-delimiting, dropping these frames costs the throughput win but cannot corrupt or hang a connection.
+/// </remarks>
+public class MultiplexingStreamWindowFrameCompatTests : TestBase
+{
+    private int droppedFrames;
+
+    public MultiplexingStreamWindowFrameCompatTests(ITestOutputHelper logger)
+        : base(logger)
+    {
+    }
+
+    /// <summary>
+    /// Verifies that a connection whose window tuning frames are all discarded in flight still transfers
+    /// every byte correctly and shuts down cleanly, exactly as if neither party had ever implemented them.
+    /// </summary>
+    [Fact]
+    public async Task TransferSucceeds_WhenWindowFramesAreDropped()
+    {
+        (Stream Item1, Stream Item2) left = FullDuplexStream.CreatePair();
+        (Stream Item1, Stream Item2) right = FullDuplexStream.CreatePair();
+
+        // Relay the two halves to each other, discarding the frames an older peer would not recognize.
+        Task relay1 = this.RelayAsync(left.Item2, right.Item2, this.TimeoutToken);
+        Task relay2 = this.RelayAsync(right.Item2, left.Item2, this.TimeoutToken);
+
+        var options = new MultiplexingStream.Options { ProtocolMajorVersion = 3 };
+        MultiplexingStream mx1 = MultiplexingStream.Create(left.Item1, options);
+        MultiplexingStream mx2 = MultiplexingStream.Create(right.Item1, options);
+
+        Task<MultiplexingStream.Channel> offerTask = mx1.OfferChannelAsync("c", this.TimeoutToken);
+        Task<MultiplexingStream.Channel> acceptTask = mx2.AcceptChannelAsync("c", this.TimeoutToken);
+        MultiplexingStream.Channel sender = await offerTask.WithCancellation(this.TimeoutToken);
+        MultiplexingStream.Channel receiver = await acceptTask.WithCancellation(this.TimeoutToken);
+
+        // Send several times the default window so the sender is forced to stall repeatedly,
+        // which is what provokes the growth requests that this test drops.
+        const int TransferSize = 4 * 1024 * 1024;
+        byte[] payload = this.GetRandomBuffer(TransferSize);
+        Task sendTask = Task.Run(
+            async () =>
+            {
+                await sender.Output.WriteAsync(payload, this.TimeoutToken);
+                await sender.Output.CompleteAsync();
+            },
+            this.TimeoutToken);
+
+        // Let the sender run ahead with nobody reading, so it is certain to exhaust its window and ask for
+        // a larger one. A prompt reader on a zero-latency pipe may never let the sender stall at all.
+        await Task.Delay(ExpectedTimeout, this.TimeoutToken);
+
+        byte[] received = new byte[TransferSize];
+        int bytesRead = 0;
+        while (bytesRead < TransferSize)
+        {
+            int justRead = await receiver.AsStream().ReadAsync(received, bytesRead, TransferSize - bytesRead, this.TimeoutToken);
+            Assert.NotEqual(0, justRead);
+            bytesRead += justRead;
+        }
+
+        await sendTask.WithCancellation(this.TimeoutToken);
+        Assert.Equal<byte>(payload, received);
+
+        // Guard against a vacuous pass: the transfer is far larger than the default window,
+        // so the sender must have stalled and asked for a larger one at least once.
+        Assert.NotEqual(0, this.droppedFrames);
+
+        await mx1.DisposeAsync();
+        await mx2.DisposeAsync();
+        await Assert.ThrowsAnyAsync<Exception>(() => Task.WhenAll(relay1, relay2)).NoThrowAwaitable();
+    }
+
+    /// <summary>
+    /// Copies self-delimiting msgpack frames from one stream to another, dropping any frame whose control
+    /// code is one an older peer would not recognize.
+    /// </summary>
+    private async Task RelayAsync(Stream from, Stream to, CancellationToken cancellationToken)
+    {
+        // These are the control codes added for window tuning. They are named here rather than referenced
+        // because the enum is internal, and because an older peer would know nothing of them either.
+        const int ChannelWindowAdjust = 7;
+        const int ChannelWindowGrowthRequest = 8;
+
+        using var reader = new MessagePackStreamReader(from);
+        while (await reader.ReadAsync(cancellationToken) is ReadOnlySequence<byte> frame)
+        {
+            var peek = new MessagePackReader(frame);
+            peek.ReadArrayHeader();
+            int code = peek.ReadInt32();
+            if (code is ChannelWindowAdjust or ChannelWindowGrowthRequest)
+            {
+                Interlocked.Increment(ref this.droppedFrames);
+                this.Logger.WriteLine("Dropping frame with control code {0}.", code);
+                continue;
+            }
+
+            byte[] bytes = frame.ToArray();
+            await to.WriteAsync(bytes, 0, bytes.Length, cancellationToken);
+            await to.FlushAsync(cancellationToken);
+        }
+    }
+}


### PR DESCRIPTION
Follow-up to #1123, continuing the work on #505.

A channel's receiving window is fixed when the channel is accepted, and that one number has to serve two irreconcilable purposes: bounding how much unread data a receiver may buffer, and bounding how much data a sender may keep in flight. On a link with real latency the second dominates — 1 MB over a 16 ms round trip caps a channel at ~62 MB/s regardless of how fast either end is — but raising the default to suit it makes every channel's worst case more expensive.

This PR lets a window grow after the fact, but only for the channels that demonstrably need it.

## How growth is decided

Growth requires evidence from **both** ends, which is what keeps it from degenerating into "buffer more, always":

- **Sender:** "I ran out of credit and still have data" (`ChannelWindowGrowthRequest`). Only the sender can observe this. A receiver that drains promptly never sees its own buffer fill, even while the sender sits blocked across the round trip — which is precisely the case this fixes. (An earlier attempt at receiver-side saturation detection never fired, for exactly this reason.)
- **Receiver:** "…and it isn't because I'm behind" — granted only while its own reader is starved inside `ReadAsync` (`ChannelWindowAdjust`). If the reader is merely behind, a bigger window would buffer more unread data without moving any more of it.

A request arriving while the receiver is busy is deferred and answered when its reader next starves. Every request is answered, including a refusal that repeats the current size, so the sender is never left waiting on a reply that won't come. Consecutive refusals back the sender off exponentially, so a channel already at its cap doesn't spend a frame pair on every subsequent stall.

Growth is ×4, bounded per channel by `Options.MaxChannelReceivingWindowSize` and per connection by `Options.MaxTotalChannelReceivingWindowSize`; budget is returned when a channel closes.

Worth noting explicitly: **a window is a limit on buffering, not an allocation.** `localWindowSize` is used only as a `Pipe` `pauseWriterThreshold` and to size ACKs, so a channel that never fills one costs nothing.

## No new protocol version

The two control codes are purely additive:

- Both the .NET and JS frame dispatchers end in a `default:` case that ignores unrecognized codes (`MultiplexingStream.cs`, `MultiplexingStream.ts`), and `(ControlCode)reader.ReadInt32()` is a plain cast that never throws.
- Frames are self-delimiting, so an unknown frame can't desync the stream.
- The exchange is **self-negotiating**: a receiver only ever grants in reply to a request, and only a peer that implements this sends one. Against an older peer, a channel spends one small ignored frame and then behaves exactly as a fixed window would.

Rather than assert this, `MultiplexingStreamWindowFrameCompatTests` relays a real connection through a filter that **drops both frame types**, and asserts that frames really were dropped so the test can't pass vacuously.

## Measurements

`LatencyBulkTransferBenchmark`, 4 MB transfer, ms (lower is better):

| one-way latency | window | v1 | before | after |
|---|---|---:|---:|---:|
| 0 ms | default | 6.7 | 13.3 | 13.5 |
| 1 ms | default | 11.4 | 17.5 | **13.5** |
| 8 ms | default | 33.2 | 94.6 | **47.7** |
| 8 ms | 4 MB | 32.1 | 31.7 | 31.6 |

Reproduced across separate runs with errors near ±1 ms. The residual gap to v1 at 8 ms is about one round trip: the first stall is *how* a channel learns it needs a bigger window, so some ramp is unavoidable.

**The loopback benchmarks are inconclusive on my machine and I'm deliberately not claiming them as evidence.** The same binary run twice gave 54.95 ms and 34.58 ms for the same case. Instrumenting a 32 MB loopback transfer showed **zero growth requests** — a prompt reader at zero latency never lets the sender stall — so the feature is simply inert there, neither helping nor hurting. Worth re-running the matrix on quieter hardware.

## Known follow-ups

- A grant can land just as a transfer ends (the reader starves then too), committing budget to a channel that no longer needs it. Bounded and released on close, but imprecise.
- Because credit rides on *examined* rather than consumed bytes, an examine-heavy reader can buffer past the window. Pre-existing, but the growable pipe's higher pause threshold removes a backstop that previously caught it (at the cost of stalling the shared read loop).
- The JS implementation doesn't request or grant growth; it interoperates unchanged.
