### PR TITLE
Reduce v1 channel offer allocations

### DIFF
--- a/src/Nerdbank.Streams/MultiplexingStream.Formatters.cs
+++ b/src/Nerdbank.Streams/MultiplexingStream.Formatters.cs
@@ -356,18 +356,17 @@ namespace Nerdbank.Streams
 
             internal override unsafe ReadOnlySequence<byte> Serialize(Channel.OfferParameters offerParameters)
             {
-                var sequence = new Sequence<byte>();
-                Span<byte> buffer = sequence.GetSpan(ControlFrameEncoding.GetMaxByteCount(offerParameters.Name.Length));
+                byte[] buffer = new byte[ControlFrameEncoding.GetMaxByteCount(offerParameters.Name.Length)];
+                int byteLength;
                 fixed (byte* pBuffer = buffer)
                 {
                     fixed (char* pName = offerParameters.Name)
                     {
-                        int byteLength = ControlFrameEncoding.GetBytes(pName, offerParameters.Name.Length, pBuffer, buffer.Length);
-                        sequence.Advance(byteLength);
+                        byteLength = ControlFrameEncoding.GetBytes(pName, offerParameters.Name.Length, pBuffer, buffer.Length);
                     }
                 }
 
-                return sequence;
+                return new ReadOnlySequence<byte>(buffer, 0, byteLength);
             }
 
             internal override unsafe Channel.OfferParameters DeserializeOfferParameters(ReadOnlySequence<byte> payload)


### PR DESCRIPTION
Encode channel names directly into a single byte array instead of constructing a temporary Sequence<byte>.

| Metric | Baseline | Candidate | Improvement |
|--------|---------:|----------:|------------:|
| Mean | 103.13 ms | 90.44 ms | 12.3% |
| Allocated | 9.16 MB | 5.43 MB | 40.7% |