### PR TITLE
Avoid linked CTS for non-cancellable pipe reads

### DIFF
--- a/src/Nerdbank.Streams/StreamPipeReader.cs
+++ b/src/Nerdbank.Streams/StreamPipeReader.cs
@@ -11,6 +11,7 @@ namespace Nerdbank.Streams
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft;
+    using Microsoft.VisualStudio.Threading;
 
     /// <summary>
     /// A <see cref="PipeReader"/> that reads from an underlying <see cref="Stream"/> exactly when told to do so
@@ -157,10 +158,10 @@ namespace Nerdbank.Streams
                 memory = this.buffer.GetMemory(this.bufferSize);
             }
 
-            using CancellationTokenSource? cts = cancellationToken.CanBeCanceled ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.readCancellationSource!.Token) : null;
+            using CancellationTokenExtensions.CombinedCancellationToken combined = cancellationToken.CombineWith(this.readCancellationSource.Token);
             try
             {
-                int bytesRead = await this.stream.ReadAsync(memory, cts?.Token ?? this.readCancellationSource!.Token).ConfigureAwait(false);
+                int bytesRead = await this.stream.ReadAsync(memory, combined.Token).ConfigureAwait(false);
                 if (bytesRead == 0)
                 {
                     this.CompleteWriting();

--- a/src/Nerdbank.Streams/StreamPipeReader.cs
+++ b/src/Nerdbank.Streams/StreamPipeReader.cs
@@ -157,27 +157,25 @@ namespace Nerdbank.Streams
                 memory = this.buffer.GetMemory(this.bufferSize);
             }
 
-            using (var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.readCancellationSource!.Token))
+            using CancellationTokenSource? cts = cancellationToken.CanBeCanceled ? CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, this.readCancellationSource!.Token) : null;
+            try
             {
-                try
+                int bytesRead = await this.stream.ReadAsync(memory, cts?.Token ?? this.readCancellationSource!.Token).ConfigureAwait(false);
+                if (bytesRead == 0)
                 {
-                    int bytesRead = await this.stream.ReadAsync(memory, cts.Token).ConfigureAwait(false);
-                    if (bytesRead == 0)
-                    {
-                        this.CompleteWriting();
-                        return new ReadResult(this.buffer, isCanceled: false, isCompleted: true);
-                    }
+                    this.CompleteWriting();
+                    return new ReadResult(this.buffer, isCanceled: false, isCompleted: true);
+                }
 
-                    lock (this.syncObject)
-                    {
-                        this.buffer.Advance(bytesRead);
-                        return new ReadResult(this.buffer, isCanceled: false, isCompleted: false);
-                    }
-                }
-                catch (OperationCanceledException) when (this.readCancellationSource.Token.IsCancellationRequested)
+                lock (this.syncObject)
                 {
-                    return new ReadResult(this.buffer, isCanceled: true, isCompleted: this.isReaderCompleted);
+                    this.buffer.Advance(bytesRead);
+                    return new ReadResult(this.buffer, isCanceled: false, isCompleted: false);
                 }
+            }
+            catch (OperationCanceledException) when (this.readCancellationSource.Token.IsCancellationRequested)
+            {
+                return new ReadResult(this.buffer, isCanceled: true, isCompleted: this.isReaderCompleted);
             }
         }
 

--- a/test/Nerdbank.Streams.Benchmark/Program.cs
+++ b/test/Nerdbank.Streams.Benchmark/Program.cs
@@ -18,6 +18,7 @@ namespace Nerdbank.Streams.Benchmark
                 typeof(ContendedChannelsBenchmark),
                 typeof(ChannelLifetimeBenchmark),
                 typeof(LatencyBulkTransferBenchmark),
+                typeof(StreamPipeReaderBenchmark),
             });
             switcher.Run(args);
         }

--- a/test/Nerdbank.Streams.Benchmark/StreamPipeReaderBenchmark.cs
+++ b/test/Nerdbank.Streams.Benchmark/StreamPipeReaderBenchmark.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Andrew Arnott. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Nerdbank.Streams.Benchmark;
+
+using System.IO;
+using System.IO.Pipelines;
+using System.Threading;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+
+/// <summary>
+/// Benchmarks asynchronous reads performed by <see cref="StreamPipeReader"/>.
+/// </summary>
+[Config(typeof(BenchmarkConfig))]
+public class StreamPipeReaderBenchmark
+{
+    private const int ReadsPerInvocation = 100;
+
+    private readonly MemoryStream stream = new MemoryStream(new byte[ReadsPerInvocation]);
+    private readonly StreamPipeReader reader;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamPipeReaderBenchmark"/> class.
+    /// </summary>
+    public StreamPipeReaderBenchmark()
+    {
+        this.reader = new StreamPipeReader(this.stream, bufferSize: 1, leaveOpen: true);
+    }
+
+    /// <summary>
+    /// Measures repeated asynchronous reads with a non-cancellable caller token.
+    /// </summary>
+    /// <returns>A task that completes when all reads finish.</returns>
+    [Benchmark(OperationsPerInvoke = ReadsPerInvocation)]
+    public async Task ReadAsyncWithCancellationTokenNone()
+    {
+        this.stream.Position = 0;
+        for (int i = 0; i < ReadsPerInvocation; i++)
+        {
+            ReadResult result = await this.reader.ReadAsync(CancellationToken.None);
+            this.reader.AdvanceTo(result.Buffer.End);
+        }
+    }
+}

--- a/test/Nerdbank.Streams.Tests/StreamUseStrictPipeReaderTests.cs
+++ b/test/Nerdbank.Streams.Tests/StreamUseStrictPipeReaderTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Buffers;
+using System.Collections.Generic;
 using System.IO.Pipelines;
 using Nerdbank.Streams;
 using NSubstitute;
@@ -53,5 +54,119 @@ public class StreamUseStrictPipeReaderTests : StreamPipeReaderTestBase
         Assert.True(result.IsCompleted);
     }
 
+    [Fact]
+    public async Task ReadAsync_NonCancellableCaller_ReusesReaderCancellationToken()
+    {
+        var stream = new RecordingReadStream(blockReads: false);
+        var reader = new StreamPipeReader(stream, bufferSize: 1, leaveOpen: true);
+
+        ReadResult result = await reader.ReadAsync(CancellationToken.None);
+        reader.AdvanceTo(result.Buffer.End);
+        result = await reader.ReadAsync(CancellationToken.None);
+        reader.AdvanceTo(result.Buffer.End);
+
+        Assert.Equal(2, stream.ReadCancellationTokens.Count);
+        Assert.True(stream.ReadCancellationTokens[0].CanBeCanceled);
+        Assert.Equal(stream.ReadCancellationTokens[0], stream.ReadCancellationTokens[1]);
+        reader.Complete();
+    }
+
+    [Fact]
+    public async Task ReadAsync_NonCancellableCaller_ObservesCancelPendingRead()
+    {
+        var stream = new RecordingReadStream(blockReads: true);
+        var reader = new StreamPipeReader(stream, bufferSize: 1, leaveOpen: true);
+
+        ValueTask<ReadResult> readTask = reader.ReadAsync(CancellationToken.None);
+
+        CancellationToken readCancellationToken = Assert.Single(stream.ReadCancellationTokens);
+        Assert.True(readCancellationToken.CanBeCanceled);
+        reader.CancelPendingRead();
+        ReadResult result = await readTask;
+        Assert.True(result.IsCanceled);
+        reader.Complete();
+    }
+
+    [Fact]
+    public async Task ReadAsync_CancellableCaller_LinksCancellationToken()
+    {
+        var stream = new RecordingReadStream(blockReads: true);
+        var reader = new StreamPipeReader(stream, bufferSize: 1, leaveOpen: true);
+        using var cts = new CancellationTokenSource();
+
+        ValueTask<ReadResult> readTask = reader.ReadAsync(cts.Token);
+
+        CancellationToken readCancellationToken = Assert.Single(stream.ReadCancellationTokens);
+        Assert.True(readCancellationToken.CanBeCanceled);
+        Assert.NotEqual(cts.Token, readCancellationToken);
+        cts.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() => readTask.AsTask());
+        reader.Complete();
+    }
+
     protected override PipeReader CreatePipeReader(Stream stream, int sizeHint = 0) => stream.UseStrictPipeReader(sizeHint);
+
+    private sealed class RecordingReadStream : Stream
+    {
+        private readonly bool blockReads;
+
+        internal RecordingReadStream(bool blockReads)
+        {
+            this.blockReads = blockReads;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        internal List<CancellationToken> ReadCancellationTokens { get; } = new();
+
+        public override void Flush() => throw new NotSupportedException();
+
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+        public override async Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            this.ReadCancellationTokens.Add(cancellationToken);
+            if (this.blockReads)
+            {
+                await Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
+            }
+
+            buffer[offset] = 1;
+            return 1;
+        }
+
+#if SPAN_BUILTIN
+
+        public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            this.ReadCancellationTokens.Add(cancellationToken);
+            if (this.blockReads)
+            {
+                await Task.Delay(TimeSpan.FromMinutes(5), cancellationToken);
+            }
+
+            buffer.Span[0] = 1;
+            return 1;
+        }
+
+#endif
+
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
 }


### PR DESCRIPTION
## Summary
- Avoid creating a linked `CancellationTokenSource` when `StreamPipeReader.ReadAsync` receives a non-cancellable caller token.
- Pass the reader cancellation token directly on that common path while retaining linked cancellation when both tokens participate.
- Add coverage for token reuse, `CancelPendingRead`, caller cancellation, and a representative benchmark.

## Performance
BenchmarkDotNet, .NET 8, 15 iterations with baseline/candidate/baseline:
- Mean: 248.2 ns -> 205.9 ns per read (17.1% faster)
- Allocated: 64 B -> 0 B per read
- Baseline drift: 0.83%

## Validation
- Release test-project build: 0 warnings, 0 errors
- Focused `StreamUseStrictPipeReaderTests.ReadAsync_*`: 10 passed across net8.0 and .NET Framework