### PR TITLE
Harden pnpm install against transient timeouts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         corepack prepare pnpm@11.12.0 --activate
         pnpm --version
     - name: ⚙️ pnpm install
-      run: corepack pnpm install --frozen-lockfile
+      run: corepack pnpm install --frozen-lockfile --fetch-retries=5 --fetch-timeout=120000
       working-directory: src/nerdbank-streams
     - name: 🛠️ pnpm build
       run: corepack pnpm build


### PR DESCRIPTION
The merge-queue failure for #1142 occurred during `pnpm install`: the npm registry download of `nerdbank-gitversioning` timed out after the default retry budget.

Increase pnpm's fetch retry count and per-request timeout so transient npm registry latency does not fail builds.